### PR TITLE
Fix dependency caching in GitHub actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,16 +20,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
+          cache: pip
+          cache-dependency-path: scripts/py/requirements.txt
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/cache@v3
-        if: ${{ !env.ACT }}
-        with:
-          path: |
-            .pyenv
-            .scripts/js/node_modules
-          key: scripts-deps-${{ hashFiles('scripts/js/package-lock.json', 'scripts/py/requirements.txt') }}
+          cache: npm
+          cache-dependency-path: scripts/js/package-lock.json
       - uses: actions/cache@v3
         if: ${{ !env.ACT }}
         with:
@@ -82,16 +79,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
+          cache: pip
+          cache-dependency-path: scripts/py/requirements.txt
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/cache@v3
-        if: ${{ !env.ACT }}
-        with:
-          path: |
-            .pyenv
-            .scripts/js/node_modules
-          key: scripts-deps-${{ hashFiles('scripts/js/package-lock.json', 'scripts/py/requirements.txt') }}
+          cache: npm
+          cache-dependency-path: scripts/js/package-lock.json
       - name: Install dependencies
         run: ./scripts/install.sh
       - name: Checkout BYAR-Chobby

--- a/.github/workflows/sync_map.yaml
+++ b/.github/workflows/sync_map.yaml
@@ -48,15 +48,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
+          cache: pip
+          cache-dependency-path: scripts/py/requirements.txt
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/cache@v3
-        with:
-          path: |
-            .pyenv
-            .scripts/js/node_modules
-          key: scripts-deps-${{ hashFiles('scripts/js/package-lock.json', 'scripts/py/requirements.txt') }}
+          cache: npm
+          cache-dependency-path: scripts/js/package-lock.json
       - name: Install dependencies
         run: ./scripts/install.sh
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
Caching the whole .pyenv directory ended up being problematic and the setup packages have built-in caching capability so let's use that.