### PR TITLE
Use SSH deploy key for creation of sync map PRs.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'sync-map-*'
     paths-ignore:
       - 'tools/**'
       - 'cloud/**'

--- a/.github/workflows/sync_map.yaml
+++ b/.github/workflows/sync_map.yaml
@@ -44,6 +44,8 @@ jobs:
             echo "pr_title=Update map ${to_sync} from rowy" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_SELF_DEPLOY_KEY }}
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This is following
https://github.com/peter-evans/create-pull-request/blob/f908c6b99c68ed4a1eee1cdb6fbc20a0464a92ed/docs/concepts-guidelines.md#push-using-ssh-deploy-keys to work around limitation of GitHub Workflows not being triggered from PRs created from other workflows.