### PR TITLE
Fix ignoring undefined firebase docs when importing from rowy

### DIFF
--- a/scripts/js/src/update_from_rowy.ts
+++ b/scripts/js/src/update_from_rowy.ts
@@ -46,9 +46,10 @@ async function fetchDocuments(collection: FirebaseFirestore.CollectionReference<
     const subFetches = [];
     for (const doc of docs) {
         const entry = doc.data();
-        if (entry) {
-            data[doc.id] = Object.fromEntries(entryKeys.filter(key => key in entry).map(key => [key, entry[key]]));
+        if (!entry) {
+            continue;
         }
+        data[doc.id] = Object.fromEntries(entryKeys.filter(key => key in entry).map(key => [key, entry[key]]));
         for (const [key, prop] of Object.entries(schema.additionalProperties.properties)) {
             if (isTableSchema(prop)) {
                 subFetches.push(fetchConcurrentlyLimit(async () => {


### PR DESCRIPTION
The code intended to do so, but improperly, it looks like it's the first time we ran into it. The reason is that when document has a subcollection, deletion in Rowy doesn't trigger deletion of subcollection recursively.

It would be cool to figure out how to cleanup that garbage in database, but that's IMHO it's very low priority at the moment.