### PR TITLE
Drop all \r from strings exported to Lua

### DIFF
--- a/scripts/js/src/gen_map_details_lua.ts
+++ b/scripts/js/src/gen_map_details_lua.ts
@@ -89,6 +89,7 @@ function serializeMapDetails(mapDetails: MapDetails): string {
     function escapeLuaString(str: string): string {
         return str
             .replaceAll('\\', '\\\\')
+            .replaceAll('\r', '')
             .replaceAll('\n', '\\n')
             .replaceAll('\'', '\\\'');
     }


### PR DESCRIPTION
That's the only other character I found next to currently escaped ones that breaks the lua code.