### PR TITLE
#474 Remove min/max height scaling, restore min/max height on webflow sync

### DIFF
--- a/scripts/js/src/derived_map_info.ts
+++ b/scripts/js/src/derived_map_info.ts
@@ -67,8 +67,8 @@ export function getDerivedInfo(
     const info = {
         width: meta.smf.mapWidth / 64,
         height: meta.smf.mapHeight / 64,
-        mapHeightMin: meta.minHeight / 64,
-        mapHeightMax: meta.maxHeight / 64,
+        mapHeightMin: meta.minHeight,
+        mapHeightMax: meta.maxHeight,
         // Defaults from spring/cont/base/maphelper/maphelper/mapdefaults.lua
         windMin: orDefault('smd' in meta ? meta.smd.minWind : meta.mapInfo.atmosphere.minWind, 5),
         windMax: orDefault('smd' in meta ? meta.smd.maxWind : meta.mapInfo.atmosphere.maxWind, 25),

--- a/scripts/js/src/sync_to_webflow.ts
+++ b/scripts/js/src/sync_to_webflow.ts
@@ -283,8 +283,8 @@ interface WebsiteMapInfo {
     bgImageUrl: string | null;
     perspectiveShotUrl: string | null;
     moreImagesUrl: string[];
-    // mapHeightMin: number;
-    // mapHeightMax: number;
+    mapHeightMin: number;
+    mapHeightMax: number;
     windMin: number;
     windMax: number;
     tidalStrength: number | null;
@@ -319,8 +319,8 @@ async function isWebflowMapInfoEqual(a: WebsiteMapInfo, b: WebsiteMapInfo): Prom
         a.title === b.title &&
         a.description === b.description &&
         a.author === b.author &&
-        // a.mapHeightMin === b.mapHeightMin &&
-        // a.mapHeightMax === b.mapHeightMax &&
+        a.mapHeightMin === b.mapHeightMin &&
+        a.mapHeightMax === b.mapHeightMax &&
         a.windMin === b.windMin &&
         a.windMax === b.windMax &&
         a.tidalStrength === b.tidalStrength &&
@@ -357,8 +357,8 @@ class WebflowMapInfo {
         this.moreImagesUrl = reqRArr(o['more-images']?.map(i => i.url));
         this.windMin = reqRNum(o['wind-min']);
         this.windMax = reqRNum(o['wind-max']);
-        // this.mapHeightMin = reqRNum(o['map-height-min']);
-        // this.mapHeightMax = reqRNum(o['map-height-max']);
+        this.mapHeightMin = reqRNum(o['map-height-min']);
+        this.mapHeightMax = reqRNum(o['map-height-max']);
         this.tidalStrength = optR(o['tidal-strength']);
         this.teamCount = reqRNum(o['team-count']);
         this.maxPlayers = reqRNum(o['max-players']);
@@ -388,8 +388,8 @@ class WebflowMapInfo {
             'more-images': await pickImages(info.moreImagesUrl, base?.item.fieldData['more-images']),
             'wind-min': info.windMin,
             'wind-max': info.windMax,
-            // 'map-height-min': info.mapHeightMin,
-            // 'map-height-max': info.mapHeightMax,
+            'map-height-min': info.mapHeightMin,
+            'map-height-max': info.mapHeightMax,
             'tidal-strength': info.tidalStrength,
             'team-count': info.teamCount,
             'max-players': info.maxPlayers,
@@ -449,8 +449,8 @@ async function buildWebflowInfo(
             perspectiveShotUrl: (map.perspectiveShot.length > 0 ? `${imagorUrlBase}fit-in/2250x/filters:format(webp):quality(85)/${rowyBucket}/${encodeURI(map.perspectiveShot[0]!.ref)}` : null),
             moreImagesUrl: map.inGameShots.map(i => `${imagorUrlBase}fit-in/2250x/filters:format(webp):quality(85)/${rowyBucket}/${encodeURI(i.ref)}`),
             // Defaults from spring/cont/base/maphelper/maphelper/mapdefaults.lua
-            // mapHeightMin: derivedInfo.mapHeightMin,
-            // mapHeightMax: derivedInfo.mapHeightMax,
+            mapHeightMin: derivedInfo.mapHeightMin,
+            mapHeightMax: derivedInfo.mapHeightMax,
             windMin: derivedInfo.windMin,
             windMax: derivedInfo.windMax,
             tidalStrength: derivedInfo.tidalStrength ?? null,

--- a/scripts/js/src/sync_to_webflow.ts
+++ b/scripts/js/src/sync_to_webflow.ts
@@ -449,8 +449,9 @@ async function buildWebflowInfo(
             perspectiveShotUrl: (map.perspectiveShot.length > 0 ? `${imagorUrlBase}fit-in/2250x/filters:format(webp):quality(85)/${rowyBucket}/${encodeURI(map.perspectiveShot[0]!.ref)}` : null),
             moreImagesUrl: map.inGameShots.map(i => `${imagorUrlBase}fit-in/2250x/filters:format(webp):quality(85)/${rowyBucket}/${encodeURI(i.ref)}`),
             // Defaults from spring/cont/base/maphelper/maphelper/mapdefaults.lua
-            mapHeightMin: derivedInfo.mapHeightMin,
-            mapHeightMax: derivedInfo.mapHeightMax,
+            // webflow min/max height fields are integers, round to ensure consistent value comparisons
+            mapHeightMin: Math.round(derivedInfo.mapHeightMin),
+            mapHeightMax: Math.round(derivedInfo.mapHeightMax),
             windMin: derivedInfo.windMin,
             windMax: derivedInfo.windMax,
             tidalStrength: derivedInfo.tidalStrength ?? null,


### PR DESCRIPTION
Using the diff script I made locally, this is the projected changes when running this version:

[diff_webflow.txt](https://github.com/user-attachments/files/26649862/diff_webflow.txt)

As mentioned in [Discord](https://discord.com/channels/549281623154229250/1461327059430146152/1492690649412014290) I'm not sure why Devil's Postpiles, Mescaline, SpeedMetal, Titan, Titan Duel, and Black Star are all coming up as having map changes. These show in my diff even without the mapHeightMin/Max changes uncommented.

Aside from those unexpected additions, the mapHeightMin and mapHeightMax values that are indicated as "will be updated" are all identical to the current webflow value except with the webflow value rounded (I believe IceXuick stated that Webflow has these fields as integers)