### PR TITLE
Change main textureMap property to be the dry texture map

### DIFF
--- a/cloud/map-parser/src/index.ts
+++ b/cloud/map-parser/src/index.ts
@@ -121,6 +121,7 @@ app.get('/parse-map/:springName', async (req, res) => {
             verbose: true,
             mipmapSize: 16,
             skipSmt: false,
+            water: false,
             // For now skip parsing resources, we will enable it once we better
             // know what kind of formats are useful for export as raw files
             // are just massive and not that usefull in cache.
@@ -143,7 +144,7 @@ app.get('/parse-map/:springName', async (req, res) => {
         }
 
         const writePromises = Object.entries(images).map(([fileName, image]) => {
-            return image.writeAsync(path.join(tempDir, fileName));  
+            return image.writeAsync(path.join(tempDir, fileName));
         });
         await Promise.all(writePromises);
 


### PR DESCRIPTION
Closes #566

Switches the map-parser service to generate the dry (no water overlay) texture as the default `texture.jpg`. The `spring-map-parser` library already produces both versions — `textureMapDry` (raw terrain) and `textureMap` (with water tinting baked in). Previously only the water-tinted version was saved to the bucket.

Since the Webflow website handles water level display dynamically, the water-tinted texture is unnecessary. Setting `water: false` in the parser config means the water-tinting step is skipped entirely — `map.textureMap` returns the dry texture directly.

Changes:
- `cloud/map-parser/src/index.ts`: added `water: false` to MapParser config

### AI / LLM usage statement

Claude Opus 4.6 used to summarize work and write the pull request.
