### PR TITLE
Allow polygon and spline startboxes alongside legacy rectangles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
           tsx scripts/js/src/update_byar_chobby_images.ts BYAR-Chobby
           cp gen/mapDetails.lua BYAR-Chobby/LuaMenu/configs/gameConfig/byar/mapDetails.lua
           cp gen/mapBoxes.conf BYAR-Chobby/LuaMenu/configs/gameConfig/byar/savedBoxes.dat
+          cp gen/lobby_maps.validated.json BYAR-Chobby/LuaMenu/configs/gameConfig/byar/lobby_maps.validated.json
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,6 @@ jobs:
           tsx scripts/js/src/update_byar_chobby_images.ts BYAR-Chobby
           cp gen/mapDetails.lua BYAR-Chobby/LuaMenu/configs/gameConfig/byar/mapDetails.lua
           cp gen/mapBoxes.conf BYAR-Chobby/LuaMenu/configs/gameConfig/byar/savedBoxes.dat
-          cp gen/lobby_maps.validated.json BYAR-Chobby/LuaMenu/configs/gameConfig/byar/lobby_maps.validated.json
       - name: Commit and push
         uses: stefanzweifel/git-auto-commit-action@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ gen/schemas/teiserver_maps.json: gen/schemas/map_modoptions.json gen/schemas/map
 gen/schemas/lobby_maps.json: gen/schemas/map_list.json
 
 # Output targets
-gen/mapDetails.lua: gen/map_list.validated.json gen/types/map_list.d.ts
+gen/mapDetails.lua: gen/map_list.validated.json gen/types/map_list.d.ts gen/map_modoptions.validated.json gen/types/map_modoptions.d.ts
 	tsx scripts/js/src/gen_map_details_lua.ts $@
 
 gen/cdn_maps.json: gen/map_list.validated.json gen/types/map_list.d.ts

--- a/schemas/map_list.yaml
+++ b/schemas/map_list.yaml
@@ -144,14 +144,10 @@ $defs:
           type: object
           title: Startbox
           properties:
-            # Two shapes are accepted, discriminated by length:
-            #   - 2 points  → axis-aligned rectangle (top-left, bottom-right)
-            #   - 3+ points → closed polygon ring; each point may carry an
-            #                 optional `strength` field for Catmull-Rom spline
-            #                 tessellation (game-side / lobby-side feature).
-            # Downstream consumers that only understand rectangles
-            # (TEIServer, SPADS) compute a bounding-box rectangle from the
-            # polygon vertices in their respective generators.
+            # Two shapes, discriminated by point count:
+            #   - 2 points: axis-aligned rectangle (top-left, bottom-right corner).
+            #   - 3+ points: closed polygon ring; each point may carry an optional
+            #     `strength` for Catmull-Rom spline tessellation (game/lobby side).
             poly:
               oneOf:
                 - $ref: "#/$defs/startboxRect"
@@ -171,9 +167,8 @@ $defs:
     title: StartboxRect
     description: >
       Legacy 2-point rectangle: top-left and bottom-right corners in the
-      0–200 normalized coordinate space. The format every existing map ships
-      today; remains the only shape the engine, SPADS and TEIServer protocols
-      understand directly.
+      0-200 normalized coordinate space. Every existing map ships this, and it
+      is the only shape the engine, SPADS and TEIServer understand directly.
     type: array
     minItems: 2
     maxItems: 2
@@ -196,12 +191,10 @@ $defs:
   startboxPolygon:
     title: StartboxPolygon
     description: >
-      Closed polygon ring of 3 or more anchor points in the 0–200 normalized
-      coordinate space. Each point may optionally carry a Catmull-Rom spline
-      strength in [0, 1] — 0 (or omitted) is a sharp polygon corner, 1 is a
-      full smooth curve. The Rowy editor snaps strength values to multiples
-      of 0.025; the schema enforces only the range so other tooling can write
-      arbitrary precision if needed.
+      Closed polygon ring of 3 or more anchor points in the 0-200 normalized
+      coordinate space. Each point may carry a Catmull-Rom spline strength in
+      [0, 1]: 0 (or omitted) is a sharp corner, 1 a full smooth curve. Rowy
+      snaps strength to multiples of 0.025; the schema enforces only the range.
     type: array
     minItems: 3
     items:

--- a/schemas/map_list.yaml
+++ b/schemas/map_list.yaml
@@ -144,26 +144,18 @@ $defs:
           type: object
           title: Startbox
           properties:
+            # Two shapes are accepted, discriminated by length:
+            #   - 2 points  → axis-aligned rectangle (top-left, bottom-right)
+            #   - 3+ points → closed polygon ring; each point may carry an
+            #                 optional `strength` field for Catmull-Rom spline
+            #                 tessellation (game-side / lobby-side feature).
+            # Downstream consumers that only understand rectangles
+            # (TEIServer, SPADS) compute a bounding-box rectangle from the
+            # polygon vertices in their respective generators.
             poly:
-              type: array
-              minItems: 2
-              maxItems: 2
-              items:
-                title: Point
-                type: object
-                properties:
-                  x:
-                    type: integer
-                    minimum: 0
-                    maximum: 200
-                  y:
-                    type: integer
-                    minimum: 0
-                    maximum: 200
-                additionalProperties: false
-                required:
-                  - x
-                  - y
+              oneOf:
+                - $ref: "#/$defs/startboxRect"
+                - $ref: "#/$defs/startboxPolygon"
           additionalProperties: false
           required:
             - poly
@@ -175,6 +167,63 @@ $defs:
     required:
       - startboxes
       - maxPlayersPerStartbox
+  startboxRect:
+    title: StartboxRect
+    description: >
+      Legacy 2-point rectangle: top-left and bottom-right corners in the
+      0–200 normalized coordinate space. The format every existing map ships
+      today; remains the only shape the engine, SPADS and TEIServer protocols
+      understand directly.
+    type: array
+    minItems: 2
+    maxItems: 2
+    items:
+      title: RectCorner
+      type: object
+      properties:
+        x:
+          type: integer
+          minimum: 0
+          maximum: 200
+        y:
+          type: integer
+          minimum: 0
+          maximum: 200
+      additionalProperties: false
+      required:
+        - x
+        - y
+  startboxPolygon:
+    title: StartboxPolygon
+    description: >
+      Closed polygon ring of 3 or more anchor points in the 0–200 normalized
+      coordinate space. Each point may optionally carry a Catmull-Rom spline
+      strength in [0, 1] — 0 (or omitted) is a sharp polygon corner, 1 is a
+      full smooth curve. The Rowy editor snaps strength values to multiples
+      of 0.025; the schema enforces only the range so other tooling can write
+      arbitrary precision if needed.
+    type: array
+    minItems: 3
+    items:
+      title: PolygonPoint
+      type: object
+      properties:
+        x:
+          type: integer
+          minimum: 0
+          maximum: 200
+        y:
+          type: integer
+          minimum: 0
+          maximum: 200
+        strength:
+          type: number
+          minimum: 0
+          maximum: 1
+      additionalProperties: false
+      required:
+        - x
+        - y
   uploadedFile:
     title: UploadedFile
     type: object

--- a/scripts/js/src/check_startboxes.ts
+++ b/scripts/js/src/check_startboxes.ts
@@ -19,10 +19,28 @@ for (const map of Object.values(maps)) {
         players.add(startboxes.length);
 
         for (const startbox of startboxes) {
-            const [a, b] = startbox.poly;
-            if (a.x >= b.x || a.y >= b.y) {
-                console.error(`Map ${map.springName} has a startbox for players ${startboxes.length} with invalid coordinates: ${JSON.stringify(startbox)}`);
-                error = true;
+            const poly = startbox.poly;
+            if (poly.length === 2) {
+                // Legacy 2-point rectangle: top-left and bottom-right corners.
+                const [a, b] = poly;
+                if (a.x >= b.x || a.y >= b.y) {
+                    console.error(`Map ${map.springName} has a startbox for players ${startboxes.length} with invalid rectangle coordinates: ${JSON.stringify(startbox)}`);
+                    error = true;
+                }
+            } else {
+                // N-point polygon: require non-degenerate area. Self-intersection
+                // and concavity are not checked here — both are valid shapes for
+                // game-side containment, which uses ray-casting.
+                let area2 = 0;
+                for (let i = 0; i < poly.length; i++) {
+                    const a = poly[i];
+                    const b = poly[(i + 1) % poly.length];
+                    area2 += a.x * b.y - b.x * a.y;
+                }
+                if (Math.abs(area2) < 1) {
+                    console.error(`Map ${map.springName} has a degenerate polygon startbox for players ${startboxes.length}: ${JSON.stringify(startbox)}`);
+                    error = true;
+                }
             }
         }
 

--- a/scripts/js/src/check_startboxes.ts
+++ b/scripts/js/src/check_startboxes.ts
@@ -28,9 +28,10 @@ for (const map of Object.values(maps)) {
                     error = true;
                 }
             } else {
-                // N-point polygon: require non-degenerate area. Self-intersection
-                // and concavity are not checked here — both are valid shapes for
-                // game-side containment, which uses ray-casting.
+                // N-point polygon: reject rings with ~zero signed (shoelace) area.
+                // Concavity and most self-intersections pass (game-side containment
+                // uses ray-casting), but a self-intersecting ring whose signed area
+                // cancels to ~0 is rejected here too.
                 let area2 = 0;
                 for (let i = 0; i < poly.length; i++) {
                     const a = poly[i];

--- a/scripts/js/src/gen_map_boxes_conf.ts
+++ b/scripts/js/src/gen_map_boxes_conf.ts
@@ -38,9 +38,26 @@ const HEADER = `#
 #?mapName:nbTeams|boxes
 `;
 
+// SPADS only understands rectangles in mapBoxes.conf (the format is
+// "x1 y1 x2 y2" per startbox). Collapse N-point polygons to their
+// bounding-box rectangle so the conf file stays valid; the polygon shape
+// is preserved in the map archive's mapconfig/map_startboxes.lua and
+// consumed game-side.
+function polyToRectCorners(poly: Startbox['poly']): { x: number; y: number }[] {
+    if (poly.length === 2) return poly;
+    let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;
+    for (const p of poly) {
+        if (p.x < xmin) xmin = p.x;
+        if (p.x > xmax) xmax = p.x;
+        if (p.y < ymin) ymin = p.y;
+        if (p.y > ymax) ymax = p.y;
+    }
+    return [{ x: xmin, y: ymin }, { x: xmax, y: ymax }];
+}
+
 function serializeStartboxes(startboxes: Startbox[]): string {
     return startboxes
-        .map(s => s.poly.map(p => `${p.x} ${p.y}`).join(' '))
+        .map(s => polyToRectCorners(s.poly).map(p => `${p.x} ${p.y}`).join(' '))
         .join(';');
 }
 

--- a/scripts/js/src/gen_map_boxes_conf.ts
+++ b/scripts/js/src/gen_map_boxes_conf.ts
@@ -40,9 +40,9 @@ const HEADER = `#
 
 // SPADS only understands rectangles in mapBoxes.conf (the format is
 // "x1 y1 x2 y2" per startbox). Collapse N-point polygons to their
-// bounding-box rectangle so the conf file stays valid; the polygon shape
-// is preserved in the map archive's mapconfig/map_startboxes.lua and
-// consumed game-side.
+// bounding-box rectangle so the conf file stays valid; the full polygon
+// shape is preserved in the mapmetadata_startboxes_set modoption (see
+// gen_map_modoptions.ts) and decoded game-side.
 function polyToRectCorners(poly: Startbox['poly']): { x: number; y: number }[] {
     if (poly.length === 2) return poly;
     let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;

--- a/scripts/js/src/gen_map_boxes_conf.ts
+++ b/scripts/js/src/gen_map_boxes_conf.ts
@@ -4,6 +4,7 @@ import { readMapList } from './maps_metadata.js';
 import fs from 'node:fs/promises';
 import { program } from '@commander-js/extra-typings';
 import { MapList, Startbox } from '../../../gen/types/map_list.js';
+import { polyBoundingRect } from './startbox_utils.js';
 
 const HEADER = `#
 # AUTOMATICALLY GENERATED FILE, DO NOT EDIT!
@@ -38,26 +39,9 @@ const HEADER = `#
 #?mapName:nbTeams|boxes
 `;
 
-// SPADS only understands rectangles in mapBoxes.conf (the format is
-// "x1 y1 x2 y2" per startbox). Collapse N-point polygons to their
-// bounding-box rectangle so the conf file stays valid; the full polygon
-// shape is preserved in the mapmetadata_startboxes_set modoption (see
-// gen_map_modoptions.ts) and decoded game-side.
-function polyToRectCorners(poly: Startbox['poly']): { x: number; y: number }[] {
-    if (poly.length === 2) return poly;
-    let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;
-    for (const p of poly) {
-        if (p.x < xmin) xmin = p.x;
-        if (p.x > xmax) xmax = p.x;
-        if (p.y < ymin) ymin = p.y;
-        if (p.y > ymax) ymax = p.y;
-    }
-    return [{ x: xmin, y: ymin }, { x: xmax, y: ymax }];
-}
-
 function serializeStartboxes(startboxes: Startbox[]): string {
     return startboxes
-        .map(s => polyToRectCorners(s.poly).map(p => `${p.x} ${p.y}`).join(' '))
+        .map(s => polyBoundingRect(s.poly).map(p => `${p.x} ${p.y}`).join(' '))
         .join(';');
 }
 

--- a/scripts/js/src/gen_map_details_lua.ts
+++ b/scripts/js/src/gen_map_details_lua.ts
@@ -4,6 +4,7 @@ import { fetchMapsMetadata, readMapList } from './maps_metadata.js';
 import fs from 'node:fs/promises';
 import { program } from '@commander-js/extra-typings';
 import { MapList } from '../../../gen/types/map_list.js';
+import { MapModoptions } from '../../../gen/types/map_modoptions.js';
 
 export interface MapDetails {
     [k: string]: {
@@ -23,7 +24,20 @@ export interface MapDetails {
         Author?: string;
         InfoText?: string;
         LastUpdate: number;
+        // base64url(zlib(json)) encoded mapmetadata_startboxes_set modoption
+        // value (see gen_map_modoptions.ts). Chobby injects it as-is and
+        // decodes it for the polygon startbox preview; absent for maps with
+        // no startbox set.
+        StartboxesSet?: string;
     };
+}
+
+type ModoptionsBySpringName = { [springName: string]: MapModoptions['modoptions'] };
+
+async function readMapModoptions(): Promise<ModoptionsBySpringName> {
+    const contents = await fs.readFile('gen/map_modoptions.validated.json', { encoding: 'utf8' });
+    const mapModoptions = JSON.parse(contents) as MapModoptions[];
+    return Object.fromEntries(mapModoptions.map(m => [m.springName, m.modoptions]));
 }
 
 function intersection<T>(a: Iterable<T>, b: Iterable<T>): T[] {
@@ -37,7 +51,7 @@ function intersection<T>(a: Iterable<T>, b: Iterable<T>): T[] {
     return intersection;
 }
 
-function buildMapDetails(maps: MapList, mapsMetadata: Map<string, any>): MapDetails {
+function buildMapDetails(maps: MapList, mapsMetadata: Map<string, any>, modoptions: ModoptionsBySpringName): MapDetails {
     const mapDetails: MapDetails = {};
     for (const id of Object.keys(maps)) {
         const mapInfo = maps[id];
@@ -62,6 +76,7 @@ function buildMapDetails(maps: MapList, mapsMetadata: Map<string, any>): MapDeta
             Author: mapInfo.author != 'UNKNOWN' ? mapInfo.author : undefined,
             InfoText: mapInfo.description,
             LastUpdate: Math.round(mapInfo.photo[0].lastModifiedTS / 1000),
+            StartboxesSet: modoptions[mapInfo.springName]?.mapmetadata_startboxes_set,
         }
     }
     return mapDetails;
@@ -84,7 +99,8 @@ function serializeMapDetails(mapDetails: MapDetails): string {
         'TeamCount',
         'Author',
         'InfoText',
-        'LastUpdate'
+        'LastUpdate',
+        'StartboxesSet'
     ];
 
     function escapeLuaString(str: string): string {
@@ -120,7 +136,8 @@ function serializeMapDetails(mapDetails: MapDetails): string {
             } else {
                 value = `'${escapeLuaString(details[field].toString())}'`;
             }
-            if (field !== 'Author' || value !== 'nil') {
+            const omitWhenNil = field === 'Author' || field === 'StartboxesSet';
+            if (!omitWhenNil || value !== 'nil') {
                 fields.push(`${field}=${value}`);
             }
         }
@@ -139,4 +156,4 @@ const maps = await readMapList();
 
 await fs.writeFile(mapDetailsPath,
     serializeMapDetails(
-        buildMapDetails(maps, await fetchMapsMetadata(maps))));
+        buildMapDetails(maps, await fetchMapsMetadata(maps), await readMapModoptions())));

--- a/scripts/js/src/gen_map_details_lua.ts
+++ b/scripts/js/src/gen_map_details_lua.ts
@@ -93,6 +93,9 @@ function serializeMapDetails(mapDetails: MapDetails): string {
         'StartboxesSet'
     ];
 
+    // Optional fields omitted when absent rather than emitted as nil.
+    const omitWhenNil = new Set(['Author', 'StartboxesSet']);
+
     function escapeLuaString(str: string): string {
         return str
             .replaceAll('\\', '\\\\')
@@ -126,8 +129,7 @@ function serializeMapDetails(mapDetails: MapDetails): string {
             } else {
                 value = `'${escapeLuaString(details[field].toString())}'`;
             }
-            const omitWhenNil = field === 'Author' || field === 'StartboxesSet';
-            if (!omitWhenNil || value !== 'nil') {
+            if (!omitWhenNil.has(field) || value !== 'nil') {
                 fields.push(`${field}=${value}`);
             }
         }

--- a/scripts/js/src/gen_map_details_lua.ts
+++ b/scripts/js/src/gen_map_details_lua.ts
@@ -1,10 +1,9 @@
 // Script generating mapDetails.lua used in BYAR-Chobby repo for maps list.
 
-import { fetchMapsMetadata, readMapList } from './maps_metadata.js';
+import { fetchMapsMetadata, readMapList, readMapModoptionsBySpringName, type ModoptionsBySpringName } from './maps_metadata.js';
 import fs from 'node:fs/promises';
 import { program } from '@commander-js/extra-typings';
 import { MapList } from '../../../gen/types/map_list.js';
-import { MapModoptions } from '../../../gen/types/map_modoptions.js';
 
 export interface MapDetails {
     [k: string]: {
@@ -24,20 +23,11 @@ export interface MapDetails {
         Author?: string;
         InfoText?: string;
         LastUpdate: number;
-        // base64url(zlib(json)) encoded mapmetadata_startboxes_set modoption
-        // value (see gen_map_modoptions.ts). Chobby injects it as-is and
-        // decodes it for the polygon startbox preview; absent for maps with
-        // no startbox set.
+        // Encoded mapmetadata_startboxes_set modoption value; Chobby injects it
+        // as-is and decodes it for the polygon startbox preview. Omitted when a
+        // map has no startbox set.
         StartboxesSet?: string;
     };
-}
-
-type ModoptionsBySpringName = { [springName: string]: MapModoptions['modoptions'] };
-
-async function readMapModoptions(): Promise<ModoptionsBySpringName> {
-    const contents = await fs.readFile('gen/map_modoptions.validated.json', { encoding: 'utf8' });
-    const mapModoptions = JSON.parse(contents) as MapModoptions[];
-    return Object.fromEntries(mapModoptions.map(m => [m.springName, m.modoptions]));
 }
 
 function intersection<T>(a: Iterable<T>, b: Iterable<T>): T[] {
@@ -156,4 +146,4 @@ const maps = await readMapList();
 
 await fs.writeFile(mapDetailsPath,
     serializeMapDetails(
-        buildMapDetails(maps, await fetchMapsMetadata(maps), await readMapModoptions())));
+        buildMapDetails(maps, await fetchMapsMetadata(maps), await readMapModoptionsBySpringName())));

--- a/scripts/js/src/gen_map_modoptions.ts
+++ b/scripts/js/src/gen_map_modoptions.ts
@@ -6,9 +6,8 @@ import stringify from "json-stable-stringify";
 import { MapModoptions } from '../../../gen/types/map_modoptions.js';
 import { StartPosConf, StartboxesInfo } from '../../../gen/types/map_list.js';
 
-// JSON -> zlib deflate -> base64url with padding stripped. Matches the transport
-// the game decoder expects and the map_modoptions value pattern
-// (^[a-zA-Z0-9_.-]+$), which forbids '=' padding.
+// base64url(zlib(json)), padding stripped: the transport the game decoder
+// expects, and the map_modoptions value pattern (^[a-zA-Z0-9_.-]+$) forbids '='.
 function encodeModoptionValue(value: unknown): string {
     const compressed = zlib.deflateSync(stringify(value));
     return compressed.toString('base64url').replace(/=+$/, '');
@@ -18,10 +17,9 @@ function encodeStartPos(startPos: StartPosConf): string {
     return encodeModoptionValue(startPos);
 }
 
-// The game resolves a startboxes arrangement by team count (set[tostring(numTeams)]).
-// maps-metadata keys startboxesSet by document id, so re-key by the arrangement's
-// team count here. check_startboxes.ts guarantees team counts are unique within a
-// set, so no key collides.
+// The game looks up arrangements by team count (set[tostring(numTeams)]), but
+// maps-metadata keys startboxesSet by document id; re-key by team count.
+// check_startboxes guarantees unique team counts per set, so none collide.
 function encodeStartboxesSet(set: Record<string, StartboxesInfo>): string {
     const byTeamCount: Record<string, StartboxesInfo> = {};
     for (const info of Object.values(set)) {

--- a/scripts/js/src/gen_map_modoptions.ts
+++ b/scripts/js/src/gen_map_modoptions.ts
@@ -4,25 +4,52 @@ import zlib from 'node:zlib';
 import { program } from '@commander-js/extra-typings';
 import stringify from "json-stable-stringify";
 import { MapModoptions } from '../../../gen/types/map_modoptions.js';
-import { StartPosConf } from '../../../gen/types/map_list.js';
+import { StartPosConf, StartboxesInfo } from '../../../gen/types/map_list.js';
 
-function encodeStartPos(startPos: StartPosConf) {
-    const str = stringify(startPos);
-    const compressed = zlib.deflateSync(str);
-    const encoded = compressed.toString('base64url').replace(/=+$/, '');
-    return encoded;
+// JSON -> zlib deflate -> base64url with padding stripped. Matches the transport
+// the game decoder expects and the map_modoptions value pattern
+// (^[a-zA-Z0-9_.-]+$), which forbids '=' padding.
+function encodeModoptionValue(value: unknown): string {
+    const compressed = zlib.deflateSync(stringify(value));
+    return compressed.toString('base64url').replace(/=+$/, '');
+}
+
+function encodeStartPos(startPos: StartPosConf): string {
+    return encodeModoptionValue(startPos);
+}
+
+// The game resolves a startboxes arrangement by team count (set[tostring(numTeams)]).
+// maps-metadata keys startboxesSet by document id, so re-key by the arrangement's
+// team count here. check_startboxes.ts guarantees team counts are unique within a
+// set, so no key collides.
+function encodeStartboxesSet(set: Record<string, StartboxesInfo>): string {
+    const byTeamCount: Record<string, StartboxesInfo> = {};
+    for (const info of Object.values(set)) {
+        byTeamCount[String(info.startboxes.length)] = info;
+    }
+    return encodeModoptionValue(byTeamCount);
 }
 
 async function genLiveMaps(): Promise<string> {
     const maps = await readMapList();
-    const mapModoptions: MapModoptions[] = Object.values(maps)
-        .filter(m => m.startPos && m.startPosActive)
-        .map(m => ({
-            springName: m.springName,
-            modoptions: {
-                mapmetadata_startpos: encodeStartPos(m.startPos!)
-            }
-        }));
+    const mapModoptions: MapModoptions[] = [];
+
+    for (const m of Object.values(maps)) {
+        const modoptions: Record<string, string> = {};
+
+        if (m.startPos && m.startPosActive) {
+            modoptions.mapmetadata_startpos = encodeStartPos(m.startPos);
+        }
+
+        if (m.startboxesSet && Object.keys(m.startboxesSet).length > 0) {
+            modoptions.mapmetadata_startboxes_set = encodeStartboxesSet(m.startboxesSet);
+        }
+
+        if (Object.keys(modoptions).length > 0) {
+            mapModoptions.push({ springName: m.springName, modoptions });
+        }
+    }
+
     mapModoptions.sort((a, b) => a.springName.localeCompare(b.springName));
     return stringify(mapModoptions);
 }

--- a/scripts/js/src/gen_spads_map_presets.ts
+++ b/scripts/js/src/gen_spads_map_presets.ts
@@ -4,11 +4,7 @@
 import fs from 'node:fs/promises';
 import { program } from '@commander-js/extra-typings';
 import { MapModoptions } from '../../../gen/types/map_modoptions.js';
-
-async function readMapModoptions(): Promise<MapModoptions[]> {
-    const contents = await fs.readFile('gen/map_modoptions.validated.json', { 'encoding': 'utf8' });
-    return JSON.parse(contents) as MapModoptions[];
-}
+import { readMapModoptions } from './maps_metadata.js';
 
 const AUTOMATED_HEADER = `#
 # AUTOMATICALLY GENERATED FILE, DO NOT EDIT!

--- a/scripts/js/src/gen_teiserver_maps.ts
+++ b/scripts/js/src/gen_teiserver_maps.ts
@@ -8,37 +8,22 @@ import type {
 } from "../../../gen/types/teiserver_maps.js";
 import { MapModoptions } from '../../../gen/types/map_modoptions.js';
 import type { StartboxesInfo } from '../../../gen/types/map_list.js';
+import { polyBoundingRect } from './startbox_utils.js';
 
-// TEIServer's data model and Tachyon protocol only carry axis-aligned
-// rectangles ({top, bottom, left, right} in [0,1] coords). When a map ships
-// an N-point polygon (or a Catmull-Rom spline) startbox, collapse it to its
-// bounding-box rectangle here so TEIServer keeps validating without a
-// schema change on its side. The full polygon shape is preserved in the
-// mapmetadata_startboxes_set modoption (see gen_map_modoptions.ts) and
-// decoded game-side; this rectified copy is only the rect-only view for
-// TEIServer/Tachyon.
+// TEIServer/Tachyon only carry axis-aligned rectangles, so collapse polygon
+// startboxes to their bounding box (see polyBoundingRect). Rebuilt via
+// [first, ...rest] so the result stays a non-empty tuple (minItems: 1).
 function rectifyStartboxes(set: StartboxesInfo[]): StartboxesInfo[] {
-  return set.map(info => ({
-    ...info,
-    // The cast covers two unrelated narrowing issues:
-    //   1) json2ts renders `minItems: 1` as a non-empty tuple
-    //      `[Startbox, ...Startbox[]]`, but `.map()` returns plain `Startbox[]`.
-    //   2) json2ts renders `minItems: 2 / maxItems: 2` as a tuple too, and the
-    //      array literal `[{x,y},{x,y}]` widens to `{x,y}[]` rather than the
-    //      tuple shape, so the `oneOf` rect branch wouldn't match without help.
-    // The runtime shape is correct in both cases; we just bypass the inference.
-    startboxes: info.startboxes.map(box => {
-      if (box.poly.length === 2) return box;
-      let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;
-      for (const p of box.poly) {
-        if (p.x < xmin) xmin = p.x;
-        if (p.x > xmax) xmax = p.x;
-        if (p.y < ymin) ymin = p.y;
-        if (p.y > ymax) ymax = p.y;
-      }
-      return { poly: [{ x: xmin, y: ymin }, { x: xmax, y: ymax }] };
-    }) as StartboxesInfo['startboxes']
-  }));
+  return set.map(info => {
+    const [first, ...rest] = info.startboxes;
+    return {
+      ...info,
+      startboxes: [
+        { poly: polyBoundingRect(first.poly) },
+        ...rest.map(box => ({ poly: polyBoundingRect(box.poly) })),
+      ],
+    };
+  });
 }
 
 const imagorUrlBase = 'https://maps-metadata.beyondallreason.dev/i/';

--- a/scripts/js/src/gen_teiserver_maps.ts
+++ b/scripts/js/src/gen_teiserver_maps.ts
@@ -7,6 +7,37 @@ import type {
   TeiserverMaps,
 } from "../../../gen/types/teiserver_maps.js";
 import { MapModoptions } from '../../../gen/types/map_modoptions.js';
+import type { StartboxesInfo } from '../../../gen/types/map_list.js';
+
+// TEIServer's data model and Tachyon protocol only carry axis-aligned
+// rectangles ({top, bottom, left, right} in [0,1] coords). When a map ships
+// an N-point polygon (or a Catmull-Rom spline) startbox, collapse it to its
+// bounding-box rectangle here so TEIServer keeps validating without a
+// schema change on its side. The polygon shape is preserved in the map
+// archive's mapconfig/map_startboxes.lua and consumed game-side.
+function rectifyStartboxes(set: StartboxesInfo[]): StartboxesInfo[] {
+  return set.map(info => ({
+    ...info,
+    // The cast covers two unrelated narrowing issues:
+    //   1) json2ts renders `minItems: 1` as a non-empty tuple
+    //      `[Startbox, ...Startbox[]]`, but `.map()` returns plain `Startbox[]`.
+    //   2) json2ts renders `minItems: 2 / maxItems: 2` as a tuple too, and the
+    //      array literal `[{x,y},{x,y}]` widens to `{x,y}[]` rather than the
+    //      tuple shape, so the `oneOf` rect branch wouldn't match without help.
+    // The runtime shape is correct in both cases; we just bypass the inference.
+    startboxes: info.startboxes.map(box => {
+      if (box.poly.length === 2) return box;
+      let xmin = Infinity, ymin = Infinity, xmax = -Infinity, ymax = -Infinity;
+      for (const p of box.poly) {
+        if (p.x < xmin) xmin = p.x;
+        if (p.x > xmax) xmax = p.x;
+        if (p.y < ymin) ymin = p.y;
+        if (p.y > ymax) ymax = p.y;
+      }
+      return { poly: [{ x: xmin, y: ymin }, { x: xmax, y: ymax }] };
+    }) as StartboxesInfo['startboxes']
+  }));
+}
 
 const imagorUrlBase = 'https://maps-metadata.beyondallreason.dev/i/';
 const rowyBucket = 'rowy-1f075.appspot.com';
@@ -39,7 +70,7 @@ async function genTeiserverMaps(): Promise<string> {
       springName: map.springName,
       displayName: map.displayName,
       thumbnail: `${imagorUrlBase}fit-in/640x640/filters:format(webp):quality(85)/${rowyBucket}/${encodeURI(map.photo[0].ref)}`,
-      startboxesSet: Object.values(map.startboxesSet || {}),
+      startboxesSet: rectifyStartboxes(Object.values(map.startboxesSet || {})),
       matchmakingQueues,
       modoptions: mapModoptions[map.springName]
     });

--- a/scripts/js/src/gen_teiserver_maps.ts
+++ b/scripts/js/src/gen_teiserver_maps.ts
@@ -1,4 +1,4 @@
-import { readMapList } from "./maps_metadata.js";
+import { readMapList, readMapModoptionsBySpringName } from "./maps_metadata.js";
 import fs from "node:fs/promises";
 import { program } from "@commander-js/extra-typings";
 import stringify from "json-stable-stringify";
@@ -6,13 +6,11 @@ import type {
   TeiserverMapInfo,
   TeiserverMaps,
 } from "../../../gen/types/teiserver_maps.js";
-import { MapModoptions } from '../../../gen/types/map_modoptions.js';
 import type { StartboxesInfo } from '../../../gen/types/map_list.js';
 import { polyBoundingRect } from './startbox_utils.js';
 
-// TEIServer/Tachyon only carry axis-aligned rectangles, so collapse polygon
-// startboxes to their bounding box (see polyBoundingRect). Rebuilt via
-// [first, ...rest] so the result stays a non-empty tuple (minItems: 1).
+// Collapse polygons to their bounding box for rect-only TEIServer/Tachyon.
+// [first, ...rest] keeps the result a non-empty tuple (minItems: 1).
 function rectifyStartboxes(set: StartboxesInfo[]): StartboxesInfo[] {
   return set.map(info => {
     const [first, ...rest] = info.startboxes;
@@ -29,15 +27,9 @@ function rectifyStartboxes(set: StartboxesInfo[]): StartboxesInfo[] {
 const imagorUrlBase = 'https://maps-metadata.beyondallreason.dev/i/';
 const rowyBucket = 'rowy-1f075.appspot.com';
 
-async function readMapModoptions(): Promise<{[springName: string]: MapModoptions['modoptions']}> {
-    const contents = await fs.readFile('gen/map_modoptions.validated.json', { 'encoding': 'utf8' });
-    const mapModoptions = JSON.parse(contents) as MapModoptions[];
-    return Object.fromEntries(mapModoptions.map((m) => [m.springName, m.modoptions]));
-}
-
 async function genTeiserverMaps(): Promise<string> {
   const maps = await readMapList();
-  const mapModoptions = await readMapModoptions();
+  const mapModoptions = await readMapModoptionsBySpringName();
 
   const tMaps: TeiserverMapInfo[] = [];
   for (const [_rowyId, map] of Object.entries(maps)) {

--- a/scripts/js/src/gen_teiserver_maps.ts
+++ b/scripts/js/src/gen_teiserver_maps.ts
@@ -13,8 +13,10 @@ import type { StartboxesInfo } from '../../../gen/types/map_list.js';
 // rectangles ({top, bottom, left, right} in [0,1] coords). When a map ships
 // an N-point polygon (or a Catmull-Rom spline) startbox, collapse it to its
 // bounding-box rectangle here so TEIServer keeps validating without a
-// schema change on its side. The polygon shape is preserved in the map
-// archive's mapconfig/map_startboxes.lua and consumed game-side.
+// schema change on its side. The full polygon shape is preserved in the
+// mapmetadata_startboxes_set modoption (see gen_map_modoptions.ts) and
+// decoded game-side; this rectified copy is only the rect-only view for
+// TEIServer/Tachyon.
 function rectifyStartboxes(set: StartboxesInfo[]): StartboxesInfo[] {
   return set.map(info => ({
     ...info,

--- a/scripts/js/src/maps_metadata.ts
+++ b/scripts/js/src/maps_metadata.ts
@@ -9,6 +9,7 @@ import { randomUUID } from 'node:crypto';
 import stream from 'node:stream/promises';
 import process from 'node:process';
 import type { MapList } from '../../../gen/types/map_list.js';
+import type { MapModoptions } from '../../../gen/types/map_modoptions.js';
 import pLimit from 'p-limit';
 import { lock } from 'proper-lockfile';
 
@@ -135,4 +136,15 @@ export async function fetchMapsMetadata(maps: MapList): Promise<Map<string, any>
 export async function readMapList(): Promise<MapList> {
     const contents = await fs.readFile('gen/map_list.validated.json', { 'encoding': 'utf8' });
     return JSON.parse(contents) as MapList;
+}
+
+export type ModoptionsBySpringName = { [springName: string]: MapModoptions['modoptions'] };
+
+export async function readMapModoptions(): Promise<MapModoptions[]> {
+    const contents = await fs.readFile('gen/map_modoptions.validated.json', { 'encoding': 'utf8' });
+    return JSON.parse(contents) as MapModoptions[];
+}
+
+export async function readMapModoptionsBySpringName(): Promise<ModoptionsBySpringName> {
+    return Object.fromEntries((await readMapModoptions()).map(m => [m.springName, m.modoptions]));
 }

--- a/scripts/js/src/startbox_utils.ts
+++ b/scripts/js/src/startbox_utils.ts
@@ -1,0 +1,19 @@
+import type { Startbox } from '../../../gen/types/map_list.js';
+
+type RectCorner = { x: number; y: number };
+
+// SPADS (mapBoxes.conf) and TEIServer/Tachyon carry only axis-aligned
+// rectangles, so collapse an N-point polygon to its bounding box. The full
+// polygon shape rides in the mapmetadata_startboxes_set modoption (see
+// gen_map_modoptions.ts) and is decoded game-side. Legacy 2-point rectangles
+// are already min/max ordered, so the bounding box is the rectangle itself.
+export function polyBoundingRect(poly: Startbox['poly']): [RectCorner, RectCorner] {
+    let xMin = Infinity, yMin = Infinity, xMax = -Infinity, yMax = -Infinity;
+    for (const p of poly) {
+        xMin = Math.min(xMin, p.x);
+        yMin = Math.min(yMin, p.y);
+        xMax = Math.max(xMax, p.x);
+        yMax = Math.max(yMax, p.y);
+    }
+    return [{ x: xMin, y: yMin }, { x: xMax, y: yMax }];
+}

--- a/scripts/js/src/startbox_utils.ts
+++ b/scripts/js/src/startbox_utils.ts
@@ -2,11 +2,9 @@ import type { Startbox } from '../../../gen/types/map_list.js';
 
 type RectCorner = { x: number; y: number };
 
-// SPADS (mapBoxes.conf) and TEIServer/Tachyon carry only axis-aligned
-// rectangles, so collapse an N-point polygon to its bounding box. The full
-// polygon shape rides in the mapmetadata_startboxes_set modoption (see
-// gen_map_modoptions.ts) and is decoded game-side. Legacy 2-point rectangles
-// are already min/max ordered, so the bounding box is the rectangle itself.
+// Rect-only consumers (SPADS, TEIServer/Tachyon) get a polygon's bounding box;
+// the full shape still reaches the game via the mapmetadata_startboxes_set
+// modoption. A 2-point rect is already min/max ordered, so it is unchanged.
 export function polyBoundingRect(poly: Startbox['poly']): [RectCorner, RectCorner] {
     let xMin = Infinity, yMin = Infinity, xMax = -Infinity, yMax = -Infinity;
     for (const p of poly) {


### PR DESCRIPTION
Closes #605

## Summary

Widens the startbox `poly` schema to accept either the legacy 2-point rectangle (current shape every existing map ships) or an N-point polygon ring with optional Catmull-Rom spline `strength` per anchor. Discriminated via JSON Schema `oneOf` so existing data validates unchanged. Generators that target rect-only consumers (TEIServer's Tachyon protocol, SPADS' `mapBoxes.conf`) compute a bounding-box rectangle from polygon vertices; the polygon shape is preserved through `gen_lobby_maps.ts` for the polygon-aware new lobby and through `sync_to_webflow.ts`'s existing `startpos-code` field unchanged.

## Changes

### schemas/map_list.yaml
- Replaced inline `poly` definition with `oneOf: [startboxRect, startboxPolygon]`
- New `$defs.startboxRect` — exactly 2 points, top-left/bottom-right corners (the existing format)
- New `$defs.startboxPolygon` — 3+ points, each with optional `strength` in `[0, 1]` for Catmull-Rom spline tessellation
- Range-only validation on `strength`. No `multipleOf` constraint to avoid float-comparison flakiness across validators; the Rowy editor enforces a 0.025 snap step at write time

### scripts/js/src/check_startboxes.ts
- Branch on `poly.length === 2`
- Rectangle branch keeps the existing corner-ordering check
- Polygon branch checks for non-degenerate area via the shoelace formula

### scripts/js/src/gen_teiserver_maps.ts
- New `rectifyStartboxes()` helper collapses N-point polygons to bounding-box rectangles before writing `teiserver_maps.json` — TEIServer's data model and Tachyon protocol stay rect-only

### scripts/js/src/gen_map_boxes_conf.ts
- New `polyToRectCorners()` helper applies the same bounding-box fallback for SPADS' `mapBoxes.conf` format

### gen_lobby_maps.ts (no change)
- bar-lobby is the polygon-aware consumer; the schema's `poly` passes through unchanged

## Verification

- All 942 existing rectangle entries across all maps validate against the new schema (Python `jsonschema` + Draft 2020-12)
- Synthetic polygon (no strength) and synthetic spline (mixed strengths including 0.025 and 1) both validate
- Counter-tests rejected as expected: 1-point poly, `strength: 2`, 2-point poly with `strength` on a corner, polygon with extra property

## Related PRs

- Core Game - https://github.com/beyond-all-reason/Beyond-All-Reason/pull/7513
- Chobby Lobby - https://github.com/beyond-all-reason/BYAR-Chobby/pull/1184
- New Lobby - https://github.com/beyond-all-reason/bar-lobby/pull/574
- New Lobby (active follow-up, amends #574): https://github.com/beyond-all-reason/bar-lobby/pull/601
- Rowy editor Fork - https://github.com/p2004a/rowy/pull/1

### AI / LLM usage statement

Claude Opus 4.7 used to assist in implementation, schema design, and validation.

