### PR TITLE
Map parser improvements

### DIFF
--- a/cloud/map-parser/README.md
+++ b/cloud/map-parser/README.md
@@ -33,6 +33,6 @@ gcloud run deploy --project=rowy-1f075 map-parser \
   --image=europe-west1-docker.pkg.dev/rowy-1f075/main/map-parser:latest \
   --region=europe-west1 \
   --service-account=rowy-functions@rowy-1f075.iam.gserviceaccount.com \
-  --memory=4Gi --cpu=1 --concurrency=2 --allow-unauthenticated \
+  --memory=8Gi --cpu=2 --concurrency=2 --allow-unauthenticated \
   --set-env-vars=BUCKET=maps-cache-8512
 ```

--- a/cloud/map-parser/README.md
+++ b/cloud/map-parser/README.md
@@ -33,6 +33,6 @@ gcloud run deploy --project=rowy-1f075 map-parser \
   --image=europe-west1-docker.pkg.dev/rowy-1f075/main/map-parser:latest \
   --region=europe-west1 \
   --service-account=rowy-functions@rowy-1f075.iam.gserviceaccount.com \
-  --memory=1Gi --cpu=1 --concurrency=2 --allow-unauthenticated \
+  --memory=4Gi --cpu=1 --concurrency=2 --allow-unauthenticated \
   --set-env-vars=BUCKET=maps-cache-8512
 ```

--- a/cloud/map-parser/package-lock.json
+++ b/cloud/map-parser/package-lock.json
@@ -13,7 +13,7 @@
         "7zip-bin": "5.1.1",
         "express": "^5.2.1",
         "jimp": "^0.22.7",
-        "spring-map-parser": "^6.4.0"
+        "spring-map-parser": "^6.4.1"
       },
       "devDependencies": {
         "@tsconfig/node24": "^24.0.4",
@@ -2755,9 +2755,9 @@
       }
     },
     "node_modules/spring-map-parser": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-6.4.0.tgz",
-      "integrity": "sha512-yzBR7xLo+nCOJT6fEpYoc9593s5kFRsU9V5TEs8CPRRcOMYPuOSbfs90UAmKgnkLaSaGyklUGtuQ1SxES0YDVw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-6.4.1.tgz",
+      "integrity": "sha512-vICy8BLHpzh0Rsm0TBHv9XFRPJCrzouSwTBmsa3owJv2IiyHtxjdmU8DBLVunBemr6Zu5n1g8BIDu7gKtDHcwg==",
       "license": "mit",
       "dependencies": {
         "7zip-bin": "5.1.1",

--- a/cloud/map-parser/package-lock.json
+++ b/cloud/map-parser/package-lock.json
@@ -14,7 +14,7 @@
         "express": "^5.2.1",
         "jimp": "^0.22.7",
         "piscina": "^5.1.4",
-        "spring-map-parser": "^6.4.1"
+        "spring-map-parser": "^6.4.2"
       },
       "devDependencies": {
         "@tsconfig/node24": "^24.0.4",
@@ -3073,9 +3073,9 @@
       }
     },
     "node_modules/spring-map-parser": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-6.4.1.tgz",
-      "integrity": "sha512-vICy8BLHpzh0Rsm0TBHv9XFRPJCrzouSwTBmsa3owJv2IiyHtxjdmU8DBLVunBemr6Zu5n1g8BIDu7gKtDHcwg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/spring-map-parser/-/spring-map-parser-6.4.2.tgz",
+      "integrity": "sha512-3Shv2LQktIzUHaU1a6RL4SDy8JNd2/e7OjNIbh97WrUTP/kkwfzye4SulaEAVDhvnsvnbJOucVhCl+QIachx8g==",
       "license": "mit",
       "dependencies": {
         "7zip-bin": "5.1.1",

--- a/cloud/map-parser/package-lock.json
+++ b/cloud/map-parser/package-lock.json
@@ -13,6 +13,7 @@
         "7zip-bin": "5.1.1",
         "express": "^5.2.1",
         "jimp": "^0.22.7",
+        "piscina": "^5.1.4",
         "spring-map-parser": "^6.4.1"
       },
       "devDependencies": {
@@ -495,6 +496,311 @@
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/@napi-rs/nice": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
+      "integrity": "sha512-xJIPs+bYuc9ASBl+cvGsKbGrJmS6fAKaSZCnT0lhahT5rhA2VVy9/EcIgd2JhtEuFOJNx7UHNn/qiTPTY4nrQw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/nice-android-arm-eabi": "1.1.1",
+        "@napi-rs/nice-android-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-arm64": "1.1.1",
+        "@napi-rs/nice-darwin-x64": "1.1.1",
+        "@napi-rs/nice-freebsd-x64": "1.1.1",
+        "@napi-rs/nice-linux-arm-gnueabihf": "1.1.1",
+        "@napi-rs/nice-linux-arm64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-arm64-musl": "1.1.1",
+        "@napi-rs/nice-linux-ppc64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-riscv64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-s390x-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-gnu": "1.1.1",
+        "@napi-rs/nice-linux-x64-musl": "1.1.1",
+        "@napi-rs/nice-openharmony-arm64": "1.1.1",
+        "@napi-rs/nice-win32-arm64-msvc": "1.1.1",
+        "@napi-rs/nice-win32-ia32-msvc": "1.1.1",
+        "@napi-rs/nice-win32-x64-msvc": "1.1.1"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm-eabi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.1.1.tgz",
+      "integrity": "sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-android-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.1.1.tgz",
+      "integrity": "sha512-blG0i7dXgbInN5urONoUCNf+DUEAavRffrO7fZSeoRMJc5qD+BJeNcpr54msPF6qfDD6kzs9AQJogZvT2KD5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-s/E7w45NaLqTGuOjC2p96pct4jRfo61xb9bU1unM/MJ/RFkKlJyJDx7OJI/O0ll/hrfpqKopuAFDV8yo0hfT7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-darwin-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-dGoEBnVpsdcC+oHHmW1LRK5eiyzLwdgNQq3BmZIav+9/5WTZwBYX7r5ZkQC07Nxd3KHOCkgbHSh4wPkH1N1LiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-freebsd-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.1.1.tgz",
+      "integrity": "sha512-kHv4kEHAylMYmlNwcQcDtXjklYp4FCf0b05E+0h6nDHsZ+F0bDe04U/tXNOqrx5CmIAth4vwfkjjUmp4c4JktQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.1.1.tgz",
+      "integrity": "sha512-E1t7K0efyKXZDoZg1LzCOLxgolxV58HCkaEkEvIYQx12ht2pa8hoBo+4OB3qh7e+QiBlp1SRf+voWUZFxyhyqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.1.1.tgz",
+      "integrity": "sha512-CIKLA12DTIZlmTaaKhQP88R3Xao+gyJxNWEn04wZwC2wmRapNnxCUZkVwggInMJvtVElA+D4ZzOU5sX4jV+SmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-arm64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.1.1.tgz",
+      "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.1.1.tgz",
+      "integrity": "sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.1.1.tgz",
+      "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-s390x-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.1.1.tgz",
+      "integrity": "sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-gnu": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.1.1.tgz",
+      "integrity": "sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-linux-x64-musl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.1.1.tgz",
+      "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-openharmony-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-openharmony-arm64/-/nice-openharmony-arm64-1.1.1.tgz",
+      "integrity": "sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-arm64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.1.1.tgz",
+      "integrity": "sha512-uoTb4eAvM5B2aj/z8j+Nv8OttPf2m+HVx3UjA5jcFxASvNhQriyCQF1OB1lHL43ZhW+VwZlgvjmP5qF3+59atA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-ia32-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.1.1.tgz",
+      "integrity": "sha512-CNQqlQT9MwuCsg1Vd/oKXiuH+TcsSPJmlAFc5frFyX/KkOh0UpBLEj7aoY656d5UKZQMQFP7vJNa1DNUNORvug==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/nice-win32-x64-msvc": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.1.1.tgz",
+      "integrity": "sha512-vB+4G/jBQCAh0jelMTY3+kgFy00Hlx2f2/1zjMoH821IbplbWZOkLiTYXQkygNTzQJTq5cvwBDgn2ppHD+bglQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodable/entities": {
@@ -2314,6 +2620,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
+      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.x"
+      },
+      "optionalDependencies": {
+        "@napi-rs/nice": "^1.0.4"
       }
     },
     "node_modules/pixelmatch": {

--- a/cloud/map-parser/package.json
+++ b/cloud/map-parser/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "start": "node ./src/index.ts",
-    "build": "tsc"
+    "typecheck": "tsc"
   },
   "keywords": [],
   "author": "BAR Developers",

--- a/cloud/map-parser/package.json
+++ b/cloud/map-parser/package.json
@@ -16,7 +16,7 @@
     "7zip-bin": "5.1.1",
     "express": "^5.2.1",
     "jimp": "^0.22.7",
-    "spring-map-parser": "^6.4.0"
+    "spring-map-parser": "^6.4.1"
   },
   "devDependencies": {
     "@tsconfig/node24": "^24.0.4",

--- a/cloud/map-parser/package.json
+++ b/cloud/map-parser/package.json
@@ -16,6 +16,7 @@
     "7zip-bin": "5.1.1",
     "express": "^5.2.1",
     "jimp": "^0.22.7",
+    "piscina": "^5.1.4",
     "spring-map-parser": "^6.4.1"
   },
   "devDependencies": {

--- a/cloud/map-parser/package.json
+++ b/cloud/map-parser/package.json
@@ -17,7 +17,7 @@
     "express": "^5.2.1",
     "jimp": "^0.22.7",
     "piscina": "^5.1.4",
-    "spring-map-parser": "^6.4.1"
+    "spring-map-parser": "^6.4.2"
   },
   "devDependencies": {
     "@tsconfig/node24": "^24.0.4",

--- a/cloud/map-parser/src/index.ts
+++ b/cloud/map-parser/src/index.ts
@@ -4,7 +4,7 @@ import { Piscina } from 'piscina';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { CACHE_VERSION } from './shared.ts';
+import { CACHE_VERSION, checkCached } from './shared.ts';
 import type { ParseResult, WorkerInput } from './shared.ts';
 
 const app = express();
@@ -52,13 +52,6 @@ const pool = new Piscina({
 // into skipQueue, which is unbounded), so we track in-flight requests here.
 let inFlight = 0;
 
-async function checkCached(springName: string): Promise<boolean> {
-    if (bucketName === 'local') return false;
-    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
-    const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
-    return exists;
-}
-
 app.get('/parse-map/:springName', async (req, res) => {
     const springName = req.params.springName;
     const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
@@ -79,7 +72,7 @@ app.get('/parse-map/:springName', async (req, res) => {
         // Fast-path: skip the queue entirely if the cache is already populated.
         // Runs on the main thread so cached requests are served while a parse
         // is in flight in the worker.
-        if (await checkCached(springName)) {
+        if (await checkCached(storage, bucketName, springName)) {
             res.status(200).json({ message: 'Cache found.', ...baseOkRes });
             return;
         }

--- a/cloud/map-parser/src/index.ts
+++ b/cloud/map-parser/src/index.ts
@@ -16,11 +16,11 @@ const execFile = promisify(child_process.execFile);
 const app = express();
 const port = process.env.PORT || 8080;
 
-const bucketName = process.env.BUCKET;
-if (!bucketName) {
+if (!process.env.BUCKET) {
     console.error('Missing required environment variable BUCKET');
     process.exit(1);
 }
+const bucketName: string = process.env.BUCKET;
 
 const publicUrlBase = process.env.PUBLIC_URL || `https://storage.googleapis.com/${bucketName}`;
 
@@ -29,9 +29,43 @@ const storage = new Storage();
 // Must change this value when making incompatible change to the cache.
 const CACHE_VERSION = 'v3';
 
-async function is7zArchiveSolid(archivePath: string): Promise<boolean> {
+// Parsing is memory-heavy; serialize to avoid concurrent OOMs.
+// MAX_QUEUE_SIZE bounds total in-flight requests (running + waiting) so a
+// burst can't pile up unbounded tempDirs / sockets.
+const MAX_QUEUE_SIZE = 3;
+const PARSE_TIMEOUT_MS = 5 * 60 * 1000;
+
+class TooManyRequestsError extends Error {
+    constructor() { super('Too many concurrent parse requests queued.'); }
+}
+
+let queueSize = 0;
+let parseQueue: Promise<void> = Promise.resolve();
+function withParseLock<T>(fn: (signal: AbortSignal) => Promise<T>, signal: AbortSignal): Promise<T> {
+    if (signal.aborted) return Promise.reject(signal.reason);
+    if (queueSize >= MAX_QUEUE_SIZE) {
+        return Promise.reject(new TooManyRequestsError());
+    }
+    queueSize++;
+    const result = parseQueue.then(() => {
+        signal.throwIfAborted();
+        return fn(signal);
+    });
+    // parseQueue must resolve (never reject) so subsequent callers chaining off it aren't rejected by a prior failure.
+    parseQueue = result.finally(() => { queueSize--; }).then(() => undefined, () => undefined);
+    return result;
+}
+
+async function checkCached(springName: string): Promise<boolean> {
+    if (bucketName === 'local') return false;
+    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
+    const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
+    return exists;
+}
+
+async function is7zArchiveSolid(archivePath: string, signal: AbortSignal): Promise<boolean> {
     const { stdout } = await execFile(
-        sevenBin.path7za, ['l', '-x!*', archivePath]
+        sevenBin.path7za, ['l', '-x!*', archivePath], { signal }
     );
 
     const solidLine = stdout
@@ -52,10 +86,10 @@ async function is7zArchiveSolid(archivePath: string): Promise<boolean> {
     }
 }
 
-async function isMapArchiveSolid(archivePath: string): Promise<boolean> {
+async function isMapArchiveSolid(archivePath: string, signal: AbortSignal): Promise<boolean> {
     switch (path.extname(archivePath)) {
         case '.sd7':
-            return await is7zArchiveSolid(archivePath);
+            return await is7zArchiveSolid(archivePath, signal);
         case '.sdz':
             return false;
         default:
@@ -63,8 +97,8 @@ async function isMapArchiveSolid(archivePath: string): Promise<boolean> {
     }
 }
 
-async function downloadMap(springName: string, destination: string): Promise<string | null> {
-    const findResponse = await fetch(`https://files-cdn.beyondallreason.dev/find?category=map&springname=${encodeURIComponent(springName)}`);
+async function downloadMap(springName: string, destination: string, signal: AbortSignal): Promise<string | null> {
+    const findResponse = await fetch(`https://files-cdn.beyondallreason.dev/find?category=map&springname=${encodeURIComponent(springName)}`, { signal });
     if (!findResponse.ok) {
         throw new Error(`Failed to find map "${springName}": ${findResponse.status} ${findResponse.statusText}`);
     }
@@ -77,51 +111,44 @@ async function downloadMap(springName: string, destination: string): Promise<str
     const mapUrl = findData[0].mirrors[0];
     const fileName = path.join(destination, findData[0].filename);
 
-    const mapResponse = await fetch(mapUrl);
+    const mapResponse = await fetch(mapUrl, { signal });
     if (!mapResponse.ok) {
         throw new Error(`Failed to download map from "${mapUrl}": ${mapResponse.status} ${mapResponse.statusText}`);
     }
     const mapFile = await fs.open(fileName, 'w');
     try {
-        await stream.pipeline(Readable.fromWeb(mapResponse.body!), mapFile.createWriteStream());
+        await stream.pipeline(Readable.fromWeb(mapResponse.body!), mapFile.createWriteStream(), { signal });
     } finally {
         await mapFile.close();
     }
     return fileName;
 }
 
-app.get('/parse-map/:springName', async (req, res) => {
-    const springName = req.params.springName;
+type ParseResult =
+    | { status: 'not_found' }
+    | { status: 'cached' }
+    | { status: 'fresh'; tempDir: string };
+
+async function parseAndCacheMap(springName: string, signal: AbortSignal): Promise<ParseResult> {
+    // Re-check cache now that we hold the lock — a parallel request may have
+    // populated it while we were queued.
+    if (await checkCached(springName)) {
+        return { status: 'cached' };
+    }
+    signal.throwIfAborted();
+
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `parse-map-`));
     try {
         const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
-        const baseOkRes = {
-            bucket: bucketName,
-            path: bucketName == 'local' ? tempDir : baseBucketPath,
-            baseUrl: `${publicUrlBase}/${encodeURI(baseBucketPath)}`,
-        };
 
-        if (bucketName !== "local") {
-            // Check if the cache exists and has the same version
-            const [alreadyCached] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
-            if (alreadyCached) {
-                res.status(200).json({
-                    message: 'Cache found.',
-                    ...baseOkRes
-                });
-                return;
-            }
-        }
-
-        // Download map file
-        const mapPath = await downloadMap(springName, tempDir);
+        const mapPath = await downloadMap(springName, tempDir, signal);
         if (!mapPath) {
-            res.status(404).json({ message: 'Map not found.' });
-            return;
+            return { status: 'not_found' };
         }
 
-        const isArchiveSolid = await isMapArchiveSolid((mapPath));
+        const isArchiveSolid = await isMapArchiveSolid(mapPath, signal);
 
+        console.log(`Starting to parse ${springName}`);
         const map = await new MapParser({
             verbose: true,
             mipmapSize: 16,
@@ -130,6 +157,8 @@ app.get('/parse-map/:springName', async (req, res) => {
             resources: ['detailNormalTex', 'specularTex'],
             parseSkybox: true,
         }).parseMap(mapPath);
+        console.log('Parsing map done');
+        signal.throwIfAborted();
 
         // Write images sequentially to limit peak memory usage.
         // Large textures are written first, then destructively scaled for
@@ -137,7 +166,10 @@ app.get('/parse-map/:springName', async (req, res) => {
         const extractedFiles: string[] = [];
 
         const writeImage = async (fileName: string, image: Jimp): Promise<void> => {
+            signal.throwIfAborted();
             await image.writeAsync(path.join(tempDir, fileName));
+            console.log(`Wrote ${fileName}`);
+            signal.throwIfAborted();
             extractedFiles.push(fileName);
         };
 
@@ -175,10 +207,11 @@ app.get('/parse-map/:springName', async (req, res) => {
 
         // Skybox
         if (map.skybox) {
-            await writeImage('skybox.png', map.skybox);
+            await writeImage('skybox.png', map.skybox!);
         }
 
         if (bucketName !== 'local') {
+            console.log('Uploading images to bucket');
             const uploadPromises = extractedFiles.map(fileName => {
                 const filePath = path.join(tempDir, fileName);
                 return storage.bucket(bucketName).upload(filePath, { destination: `${baseBucketPath}/${fileName}` });
@@ -209,27 +242,87 @@ app.get('/parse-map/:springName', async (req, res) => {
             extractedFiles
         };
 
+        signal.throwIfAborted();
         const metadataPath = path.join(tempDir, 'metadata.json');
-        await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+        await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), { signal });
         if (bucketName !== 'local') {
+            console.log('Writing metadata.json to bucket');
             await storage.bucket(bucketName).upload(metadataPath, { destination: `${baseBucketPath}/metadata.json` });
         }
 
-        res.status(200).json({
-            message: 'Cache generated.',
-            ...baseOkRes
-        });
-
-    } catch (error) {
-        console.error(error);
-        res.status(500).json({ message: 'Internal server error.' });
+        console.log(`Finished parsing ${springName}`);
+        return { status: 'fresh', tempDir };
     } finally {
         if (bucketName !== 'local') {
-            // Cleanup local temp files
-            await fs.rm(tempDir, { recursive: true });
+            await fs.rm(tempDir, { recursive: true, force: true })
+                .catch(err => console.error(`Failed to clean up ${tempDir}:`, err));
         } else {
             console.log(`Wrote files to ${tempDir}`);
         }
+    }
+}
+
+app.get('/parse-map/:springName', async (req, res) => {
+    const springName = req.params.springName;
+    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
+    const baseOkRes = {
+        bucket: bucketName,
+        path: bucketName == 'local' ? '' : baseBucketPath,
+        baseUrl: `${publicUrlBase}/${encodeURI(baseBucketPath)}`,
+    };
+
+    const reqAbort = new AbortController();
+    const onClose = () => {
+        if (!res.writableEnded) reqAbort.abort(new Error('Client disconnected'));
+    };
+    req.on('close', onClose);
+    const signal = AbortSignal.any([reqAbort.signal, AbortSignal.timeout(PARSE_TIMEOUT_MS)]);
+
+    try {
+        // Fast-path: skip the queue entirely if the cache is already populated.
+        if (await checkCached(springName)) {
+            res.status(200).json({ message: 'Cache found.', ...baseOkRes });
+            return;
+        }
+
+        const result = await withParseLock(
+            (s) => parseAndCacheMap(springName, s),
+            signal,
+        );
+
+        if (result.status === 'not_found') {
+            console.log(`Map ${springName} not found`);
+            res.status(404).json({ message: 'Map not found.' });
+            return;
+        }
+
+        res.status(200).json({
+            message: result.status === 'cached' ? 'Cache found.' : 'Cache generated.',
+            ...baseOkRes,
+            ...(result.status === 'fresh' && bucketName === 'local' ? { path: result.tempDir } : {}),
+        });
+    } catch (error) {
+        if (error instanceof TooManyRequestsError) {
+            if (!res.headersSent) {
+                res.status(429).json({ message: 'Too many concurrent requests, try again later.' });
+            }
+            return;
+        }
+        if (signal.aborted) {
+            console.error('Parse aborted:', signal.reason);
+            // Only the timeout branch needs a response; if reqAbort fired the
+            // client is gone and writes are no-ops.
+            if (!res.headersSent && !reqAbort.signal.aborted) {
+                res.status(504).json({ message: 'Request timed out.' });
+            }
+            return;
+        }
+        console.error(error);
+        if (!res.headersSent) {
+            res.status(500).json({ message: 'Internal server error.' });
+        }
+    } finally {
+        req.off('close', onClose);
     }
 });
 

--- a/cloud/map-parser/src/index.ts
+++ b/cloud/map-parser/src/index.ts
@@ -165,25 +165,17 @@ app.get('/parse-map/:springName', async (req, res) => {
         if (map.resources) {
             for (const [resource, image] of Object.entries(map.resources) as [string, Jimp | undefined][]) {
                 if (image) {
-                    try {
-                        if (image.getWidth() > texW || image.getHeight() > texH) {
-                            image.scaleToFit(texW, texH);
-                        }
-                        await writeImage(`res_${resource}.png`, image);
-                    } catch (err) {
-                        console.warn(`Failed to write resource ${resource}:`, err);
+                    if (image.getWidth() > texW || image.getHeight() > texH) {
+                        image.scaleToFit(texW, texH);
                     }
+                    await writeImage(`res_${resource}.png`, image);
                 }
             }
         }
 
         // Skybox
         if (map.skybox) {
-            try {
-                await writeImage('skybox.png', map.skybox);
-            } catch (err) {
-                console.warn(`Failed to write skybox:`, err);
-            }
+            await writeImage('skybox.png', map.skybox);
         }
 
         if (bucketName !== 'local') {

--- a/cloud/map-parser/src/index.ts
+++ b/cloud/map-parser/src/index.ts
@@ -1,17 +1,11 @@
 import express from 'express';
 import { Storage } from '@google-cloud/storage';
-import { MapParser } from 'spring-map-parser';
+import { Piscina } from 'piscina';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { promisify } from 'node:util';
-import child_process from 'node:child_process';
-import stream from 'node:stream/promises';
-import { Readable } from 'node:stream';
-import sevenBin from '7zip-bin';
-import Jimp from 'jimp';
-
-const execFile = promisify(child_process.execFile);
+import { CACHE_VERSION } from './shared.ts';
+import type { ParseResult, WorkerInput } from './shared.ts';
 
 const app = express();
 const port = process.env.PORT || 8080;
@@ -26,240 +20,43 @@ const publicUrlBase = process.env.PUBLIC_URL || `https://storage.googleapis.com/
 
 const storage = new Storage();
 
-// Must change this value when making incompatible change to the cache.
-const CACHE_VERSION = 'v3';
-
-// Parsing is memory-heavy; serialize to avoid concurrent OOMs.
-// MAX_QUEUE_SIZE bounds total in-flight requests (running + waiting) so a
-// burst can't pile up unbounded tempDirs / sockets.
-const MAX_QUEUE_SIZE = 3;
-const PARSE_TIMEOUT_MS = 5 * 60 * 1000;
-
-class TooManyRequestsError extends Error {
-    constructor() { super('Too many concurrent parse requests queued.'); }
-}
-
-let queueSize = 0;
-let parseQueue: Promise<void> = Promise.resolve();
-function withParseLock<T>(fn: (signal: AbortSignal) => Promise<T>, signal: AbortSignal): Promise<T> {
-    if (signal.aborted) return Promise.reject(signal.reason);
-    if (queueSize >= MAX_QUEUE_SIZE) {
-        return Promise.reject(new TooManyRequestsError());
+function envInt(name: string, defaultValue: number): number {
+    const raw = process.env[name];
+    if (raw === undefined || raw === '') return defaultValue;
+    const n = Number(raw);
+    if (!Number.isInteger(n) || n < 0) {
+        console.error(`Invalid ${name}=${raw}, expected non-negative integer`);
+        process.exit(1);
     }
-    queueSize++;
-    const result = parseQueue.then(() => {
-        signal.throwIfAborted();
-        return fn(signal);
-    });
-    // parseQueue must resolve (never reject) so subsequent callers chaining off it aren't rejected by a prior failure.
-    parseQueue = result.finally(() => { queueSize--; }).then(() => undefined, () => undefined);
-    return result;
+    return n;
 }
+
+// Parsing is memory- and CPU-heavy; cap concurrent parses and queued requests
+// so a burst can't pile up unbounded. Cached requests bypass the pool entirely
+// via the fast-path check below.
+const PARSE_CONCURRENCY = envInt('PARSE_CONCURRENCY', 1);
+const PARSE_MAX_QUEUED = envInt('PARSE_MAX_QUEUED', 2);
+const MAX_INFLIGHT = PARSE_CONCURRENCY + PARSE_MAX_QUEUED;
+const PARSE_TIMEOUT_MS = envInt('PARSE_TIMEOUT_MS', 5 * 60 * 1000);
+
+// minThreads === maxThreads is load-bearing: when piscina aborts the running
+// task it terminates the worker, then calls _ensureMinimumWorkers to spawn a
+// replacement. If minThreads is lower, queued tasks can orphan.
+const pool = new Piscina({
+    filename: new URL('./parse-worker.ts', import.meta.url).href,
+    minThreads: PARSE_CONCURRENCY,
+    maxThreads: PARSE_CONCURRENCY,
+});
+
+// Piscina's own maxQueue / queueSize don't apply to abortable tasks (they go
+// into skipQueue, which is unbounded), so we track in-flight requests here.
+let inFlight = 0;
 
 async function checkCached(springName: string): Promise<boolean> {
     if (bucketName === 'local') return false;
     const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
     const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
     return exists;
-}
-
-async function is7zArchiveSolid(archivePath: string, signal: AbortSignal): Promise<boolean> {
-    const { stdout } = await execFile(
-        sevenBin.path7za, ['l', '-x!*', archivePath], { signal }
-    );
-
-    const solidLine = stdout
-        .split('\n')
-        .find((line) => line.trim().startsWith('Solid ='));
-
-    if (!solidLine) {
-        throw new Error('Solid information not found about the archive.');
-    }
-
-    switch (solidLine.split('=')[1].trim()) {
-        case '+':
-            return true;
-        case '-':
-            return false;
-        default:
-            throw new Error('Unexpected value for the solid archive, expected + or -.');
-    }
-}
-
-async function isMapArchiveSolid(archivePath: string, signal: AbortSignal): Promise<boolean> {
-    switch (path.extname(archivePath)) {
-        case '.sd7':
-            return await is7zArchiveSolid(archivePath, signal);
-        case '.sdz':
-            return false;
-        default:
-            throw new Error('Only .sd7 and .sdz files supported');
-    }
-}
-
-async function downloadMap(springName: string, destination: string, signal: AbortSignal): Promise<string | null> {
-    const findResponse = await fetch(`https://files-cdn.beyondallreason.dev/find?category=map&springname=${encodeURIComponent(springName)}`, { signal });
-    if (!findResponse.ok) {
-        throw new Error(`Failed to find map "${springName}": ${findResponse.status} ${findResponse.statusText}`);
-    }
-    const findData = await findResponse.json() as Array<{ mirrors: string[], filename: string }>;
-
-    if (findData.length === 0) {
-        return null;
-    }
-
-    const mapUrl = findData[0].mirrors[0];
-    const fileName = path.join(destination, findData[0].filename);
-
-    const mapResponse = await fetch(mapUrl, { signal });
-    if (!mapResponse.ok) {
-        throw new Error(`Failed to download map from "${mapUrl}": ${mapResponse.status} ${mapResponse.statusText}`);
-    }
-    const mapFile = await fs.open(fileName, 'w');
-    try {
-        await stream.pipeline(Readable.fromWeb(mapResponse.body!), mapFile.createWriteStream(), { signal });
-    } finally {
-        await mapFile.close();
-    }
-    return fileName;
-}
-
-type ParseResult =
-    | { status: 'not_found' }
-    | { status: 'cached' }
-    | { status: 'fresh'; tempDir: string };
-
-async function parseAndCacheMap(springName: string, signal: AbortSignal): Promise<ParseResult> {
-    // Re-check cache now that we hold the lock — a parallel request may have
-    // populated it while we were queued.
-    if (await checkCached(springName)) {
-        return { status: 'cached' };
-    }
-    signal.throwIfAborted();
-
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), `parse-map-`));
-    try {
-        const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
-
-        const mapPath = await downloadMap(springName, tempDir, signal);
-        if (!mapPath) {
-            return { status: 'not_found' };
-        }
-
-        const isArchiveSolid = await isMapArchiveSolid(mapPath, signal);
-
-        console.log(`Starting to parse ${springName}`);
-        const map = await new MapParser({
-            verbose: true,
-            mipmapSize: 16,
-            skipSmt: false,
-            parseResources: true,
-            resources: ['detailNormalTex', 'specularTex'],
-            parseSkybox: true,
-        }).parseMap(mapPath);
-        console.log('Parsing map done');
-        signal.throwIfAborted();
-
-        // Write images sequentially to limit peak memory usage.
-        // Large textures are written first, then destructively scaled for
-        // previews so the full-resolution buffer can be garbage-collected.
-        const extractedFiles: string[] = [];
-
-        const writeImage = async (fileName: string, image: Jimp): Promise<void> => {
-            signal.throwIfAborted();
-            await image.writeAsync(path.join(tempDir, fileName));
-            console.log(`Wrote ${fileName}`);
-            signal.throwIfAborted();
-            extractedFiles.push(fileName);
-        };
-
-        // Capture texture dimensions before any destructive scaling
-        const texW = map.textureMap!.getWidth();
-        const texH = map.textureMap!.getHeight();
-
-        // Texture map (largest images)
-        await writeImage('texture.jpg', map.textureMap!.quality(90));
-        await writeImage('texture-preview.jpg', map.textureMap!.scaleToFit(600, 600).quality(80));
-
-        // Dry texture (without water overlay)
-        await writeImage('texture-dry.jpg', map.textureMapDry!.quality(90));
-        await writeImage('texture-dry-preview.jpg', map.textureMapDry!.scaleToFit(600, 600).quality(80));
-
-        // Smaller maps can be written in parallel
-        await Promise.all([
-            writeImage('height.png', map.heightMap!),
-            writeImage('type.png', map.typeMap!),
-            writeImage('metal.png', map.metalMap!),
-            writeImage('mini.jpg', map.miniMap!.quality(85)),
-        ]);
-
-        // Resource images — scale down to fit texture dimensions but never upscale
-        if (map.resources) {
-            for (const [resource, image] of Object.entries(map.resources) as [string, Jimp | undefined][]) {
-                if (image) {
-                    if (image.getWidth() > texW || image.getHeight() > texH) {
-                        image.scaleToFit(texW, texH);
-                    }
-                    await writeImage(`res_${resource}.png`, image);
-                }
-            }
-        }
-
-        // Skybox
-        if (map.skybox) {
-            await writeImage('skybox.png', map.skybox!);
-        }
-
-        if (bucketName !== 'local') {
-            console.log('Uploading images to bucket');
-            const uploadPromises = extractedFiles.map(fileName => {
-                const filePath = path.join(tempDir, fileName);
-                return storage.bucket(bucketName).upload(filePath, { destination: `${baseBucketPath}/${fileName}` });
-            });
-            await Promise.all(uploadPromises);
-        }
-
-        // Create smf object copy without tables that contain a lot of data.
-        let smfCopy: any = undefined;
-        if (map.smf) {
-            smfCopy = Object.assign({}, map.smf);
-            for (const prop of ['heightMap', 'metalMap', 'miniMap', 'typeMap', 'tileIndexMap', 'heightMapValues']) {
-                delete smfCopy[prop];
-            }
-        }
-
-        // Save metadata as JSON
-        const metadata = {
-            mapInfo: map.mapInfo,
-            minHeight: map.minHeight,
-            maxHeight: map.maxHeight,
-            fileName: map.fileNameWithExt,
-            springName: springName,
-            isArchiveSolid,
-            smd: map.smd,
-            smf: smfCopy,
-            cacheVersion: CACHE_VERSION,
-            extractedFiles
-        };
-
-        signal.throwIfAborted();
-        const metadataPath = path.join(tempDir, 'metadata.json');
-        await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2), { signal });
-        if (bucketName !== 'local') {
-            console.log('Writing metadata.json to bucket');
-            await storage.bucket(bucketName).upload(metadataPath, { destination: `${baseBucketPath}/metadata.json` });
-        }
-
-        console.log(`Finished parsing ${springName}`);
-        return { status: 'fresh', tempDir };
-    } finally {
-        if (bucketName !== 'local') {
-            await fs.rm(tempDir, { recursive: true, force: true })
-                .catch(err => console.error(`Failed to clean up ${tempDir}:`, err));
-        } else {
-            console.log(`Wrote files to ${tempDir}`);
-        }
-    }
 }
 
 app.get('/parse-map/:springName', async (req, res) => {
@@ -280,34 +77,45 @@ app.get('/parse-map/:springName', async (req, res) => {
 
     try {
         // Fast-path: skip the queue entirely if the cache is already populated.
+        // Runs on the main thread so cached requests are served while a parse
+        // is in flight in the worker.
         if (await checkCached(springName)) {
             res.status(200).json({ message: 'Cache found.', ...baseOkRes });
             return;
         }
 
-        const result = await withParseLock(
-            (s) => parseAndCacheMap(springName, s),
-            signal,
-        );
-
-        if (result.status === 'not_found') {
-            console.log(`Map ${springName} not found`);
-            res.status(404).json({ message: 'Map not found.' });
+        if (inFlight >= MAX_INFLIGHT) {
+            res.status(429).json({ message: 'Too many concurrent requests, try again later.' });
             return;
         }
 
-        res.status(200).json({
-            message: result.status === 'cached' ? 'Cache found.' : 'Cache generated.',
-            ...baseOkRes,
-            ...(result.status === 'fresh' && bucketName === 'local' ? { path: result.tempDir } : {}),
-        });
-    } catch (error) {
-        if (error instanceof TooManyRequestsError) {
-            if (!res.headersSent) {
-                res.status(429).json({ message: 'Too many concurrent requests, try again later.' });
+        // Main thread owns the tempDir so cleanup is guaranteed even when
+        // piscina terminates the worker on abort (no cooperative `finally`).
+        const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'parse-map-'));
+        inFlight++;
+        try {
+            const input: WorkerInput = { springName, tempDir };
+            const result: ParseResult = await pool.run(input, { signal });
+
+            if (result.status === 'not_found') {
+                console.log(`Map ${springName} not found`);
+                res.status(404).json({ message: 'Map not found.' });
+                return;
             }
-            return;
+
+            res.status(200).json({
+                message: result.status === 'cached' ? 'Cache found.' : 'Cache generated.',
+                ...baseOkRes,
+                ...(result.status === 'fresh' && bucketName === 'local' ? { path: tempDir } : {}),
+            });
+        } finally {
+            inFlight--;
+            if (bucketName !== 'local') {
+                await fs.rm(tempDir, { recursive: true, force: true })
+                    .catch(err => console.error(`Failed to clean up ${tempDir}:`, err));
+            }
         }
+    } catch (error) {
         if (signal.aborted) {
             console.error('Parse aborted:', signal.reason);
             // Only the timeout branch needs a response; if reqAbort fired the

--- a/cloud/map-parser/src/parse-worker.ts
+++ b/cloud/map-parser/src/parse-worker.ts
@@ -1,0 +1,207 @@
+import { Storage } from '@google-cloud/storage';
+import { MapParser } from 'spring-map-parser';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import child_process from 'node:child_process';
+import stream from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import sevenBin from '7zip-bin';
+import Jimp from 'jimp';
+import { CACHE_VERSION } from './shared.ts';
+import type { ParseResult, WorkerInput } from './shared.ts';
+
+const execFile = promisify(child_process.execFile);
+
+const storage = new Storage();
+const bucketName: string = process.env.BUCKET!;
+
+async function checkCached(springName: string): Promise<boolean> {
+    if (bucketName === 'local') return false;
+    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
+    const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
+    return exists;
+}
+
+async function is7zArchiveSolid(archivePath: string): Promise<boolean> {
+    const { stdout } = await execFile(sevenBin.path7za, ['l', '-x!*', archivePath]);
+
+    const solidLine = stdout
+        .split('\n')
+        .find((line) => line.trim().startsWith('Solid ='));
+
+    if (!solidLine) {
+        throw new Error('Solid information not found about the archive.');
+    }
+
+    switch (solidLine.split('=')[1].trim()) {
+        case '+':
+            return true;
+        case '-':
+            return false;
+        default:
+            throw new Error('Unexpected value for the solid archive, expected + or -.');
+    }
+}
+
+async function isMapArchiveSolid(archivePath: string): Promise<boolean> {
+    switch (path.extname(archivePath)) {
+        case '.sd7':
+            return await is7zArchiveSolid(archivePath);
+        case '.sdz':
+            return false;
+        default:
+            throw new Error('Only .sd7 and .sdz files supported');
+    }
+}
+
+async function downloadMap(springName: string, destination: string): Promise<string | null> {
+    const findResponse = await fetch(`https://files-cdn.beyondallreason.dev/find?category=map&springname=${encodeURIComponent(springName)}`);
+    if (!findResponse.ok) {
+        throw new Error(`Failed to find map "${springName}": ${findResponse.status} ${findResponse.statusText}`);
+    }
+    const findData = await findResponse.json() as Array<{ mirrors: string[], filename: string }>;
+
+    if (findData.length === 0) {
+        return null;
+    }
+
+    const mapUrl = findData[0].mirrors[0];
+    const fileName = path.join(destination, findData[0].filename);
+
+    const mapResponse = await fetch(mapUrl);
+    if (!mapResponse.ok) {
+        throw new Error(`Failed to download map from "${mapUrl}": ${mapResponse.status} ${mapResponse.statusText}`);
+    }
+    const mapFile = await fs.open(fileName, 'w');
+    try {
+        await stream.pipeline(Readable.fromWeb(mapResponse.body!), mapFile.createWriteStream());
+    } finally {
+        await mapFile.close();
+    }
+    return fileName;
+}
+
+async function parseAndCacheMap({ springName, tempDir }: WorkerInput): Promise<ParseResult> {
+    // Re-check cache: while this task was queued (potentially minutes behind
+    // an in-flight parse), another instance may have populated the bucket.
+    if (await checkCached(springName)) {
+        return { status: 'cached' };
+    }
+
+    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
+
+    console.log(`Downloading ${springName}`);
+    const mapPath = await downloadMap(springName, tempDir);
+    if (!mapPath) {
+        return { status: 'not_found' };
+    }
+
+    const isArchiveSolid = await isMapArchiveSolid(mapPath);
+
+    console.log(`Starting to parse ${springName}`);
+    const map = await new MapParser({
+        verbose: true,
+        mipmapSize: 16,
+        skipSmt: false,
+        parseResources: true,
+        resources: ['detailNormalTex', 'specularTex'],
+        parseSkybox: true,
+    }).parseMap(mapPath);
+    console.log('Parsing map done');
+
+    // Write images sequentially to limit peak memory usage.
+    // Large textures are written first, then destructively scaled for
+    // previews so the full-resolution buffer can be garbage-collected.
+    const extractedFiles: string[] = [];
+
+    const writeImage = async (fileName: string, image: Jimp): Promise<void> => {
+        await image.writeAsync(path.join(tempDir, fileName));
+        console.log(`Wrote ${fileName}`);
+        extractedFiles.push(fileName);
+    };
+
+    // Capture texture dimensions before any destructive scaling
+    const texW = map.textureMap!.getWidth();
+    const texH = map.textureMap!.getHeight();
+
+    // Texture map (largest images)
+    await writeImage('texture.jpg', map.textureMap!.quality(90));
+    await writeImage('texture-preview.jpg', map.textureMap!.scaleToFit(600, 600).quality(80));
+
+    // Dry texture (without water overlay)
+    await writeImage('texture-dry.jpg', map.textureMapDry!.quality(90));
+    await writeImage('texture-dry-preview.jpg', map.textureMapDry!.scaleToFit(600, 600).quality(80));
+
+    // Smaller maps can be written in parallel
+    await Promise.all([
+        writeImage('height.png', map.heightMap!),
+        writeImage('type.png', map.typeMap!),
+        writeImage('metal.png', map.metalMap!),
+        writeImage('mini.jpg', map.miniMap!.quality(85)),
+    ]);
+
+    // Resource images — scale down to fit texture dimensions but never upscale
+    if (map.resources) {
+        for (const [resource, image] of Object.entries(map.resources) as [string, Jimp | undefined][]) {
+            if (image) {
+                if (image.getWidth() > texW || image.getHeight() > texH) {
+                    image.scaleToFit(texW, texH);
+                }
+                await writeImage(`res_${resource}.png`, image);
+            }
+        }
+    }
+
+    // Skybox
+    if (map.skybox) {
+        await writeImage('skybox.png', map.skybox!);
+    }
+
+    if (bucketName !== 'local') {
+        console.log('Uploading images to bucket');
+        const uploadPromises = extractedFiles.map(fileName => {
+            const filePath = path.join(tempDir, fileName);
+            return storage.bucket(bucketName).upload(filePath, { destination: `${baseBucketPath}/${fileName}` });
+        });
+        await Promise.all(uploadPromises);
+    }
+
+    // Create smf object copy without tables that contain a lot of data.
+    let smfCopy: any = undefined;
+    if (map.smf) {
+        smfCopy = Object.assign({}, map.smf);
+        for (const prop of ['heightMap', 'metalMap', 'miniMap', 'typeMap', 'tileIndexMap', 'heightMapValues']) {
+            delete smfCopy[prop];
+        }
+    }
+
+    // Save metadata as JSON
+    const metadata = {
+        mapInfo: map.mapInfo,
+        minHeight: map.minHeight,
+        maxHeight: map.maxHeight,
+        fileName: map.fileNameWithExt,
+        springName: springName,
+        isArchiveSolid,
+        smd: map.smd,
+        smf: smfCopy,
+        cacheVersion: CACHE_VERSION,
+        extractedFiles
+    };
+
+    const metadataPath = path.join(tempDir, 'metadata.json');
+    await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+    if (bucketName !== 'local') {
+        console.log('Writing metadata.json to bucket');
+        await storage.bucket(bucketName).upload(metadataPath, { destination: `${baseBucketPath}/metadata.json` });
+    }
+
+    console.log(`Finished parsing ${springName}`);
+    if (bucketName === 'local') {
+        console.log(`Wrote files to ${tempDir}`);
+    }
+    return { status: 'fresh' };
+}
+
+export default parseAndCacheMap;

--- a/cloud/map-parser/src/parse-worker.ts
+++ b/cloud/map-parser/src/parse-worker.ts
@@ -8,20 +8,13 @@ import stream from 'node:stream/promises';
 import { Readable } from 'node:stream';
 import sevenBin from '7zip-bin';
 import Jimp from 'jimp';
-import { CACHE_VERSION } from './shared.ts';
+import { CACHE_VERSION, checkCached } from './shared.ts';
 import type { ParseResult, WorkerInput } from './shared.ts';
 
 const execFile = promisify(child_process.execFile);
 
 const storage = new Storage();
 const bucketName: string = process.env.BUCKET!;
-
-async function checkCached(springName: string): Promise<boolean> {
-    if (bucketName === 'local') return false;
-    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
-    const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
-    return exists;
-}
 
 async function is7zArchiveSolid(archivePath: string): Promise<boolean> {
     const { stdout } = await execFile(sevenBin.path7za, ['l', '-x!*', archivePath]);
@@ -85,7 +78,7 @@ async function downloadMap(springName: string, destination: string): Promise<str
 async function parseAndCacheMap({ springName, tempDir }: WorkerInput): Promise<ParseResult> {
     // Re-check cache: while this task was queued (potentially minutes behind
     // an in-flight parse), another instance may have populated the bucket.
-    if (await checkCached(springName)) {
+    if (await checkCached(storage, bucketName, springName)) {
         return { status: 'cached' };
     }
 

--- a/cloud/map-parser/src/parse-worker.ts
+++ b/cloud/map-parser/src/parse-worker.ts
@@ -111,6 +111,9 @@ async function parseAndCacheMap({ springName, tempDir }: WorkerInput): Promise<P
     }).parseMap(mapPath);
     console.log('Parsing map done');
 
+    // Cleanup map file as it's not needed anymore and wastes ram.
+    await fs.rm(mapPath);
+
     // Write images sequentially to limit peak memory usage.
     // Large textures are written first, then destructively scaled for
     // previews so the full-resolution buffer can be garbage-collected.

--- a/cloud/map-parser/src/parse-worker.ts
+++ b/cloud/map-parser/src/parse-worker.ts
@@ -107,6 +107,7 @@ async function parseAndCacheMap({ springName, tempDir }: WorkerInput): Promise<P
         parseResources: true,
         resources: ['detailNormalTex', 'specularTex'],
         parseSkybox: true,
+        tmpDir: path.join(tempDir, 'extract'),
     }).parseMap(mapPath);
     console.log('Parsing map done');
 

--- a/cloud/map-parser/src/shared.ts
+++ b/cloud/map-parser/src/shared.ts
@@ -1,3 +1,5 @@
+import type { Storage } from '@google-cloud/storage';
+
 // Must change CACHE_VERSION when making incompatible change to the cache.
 export const CACHE_VERSION = 'v3';
 
@@ -10,3 +12,10 @@ export type WorkerInput = {
     springName: string;
     tempDir: string;
 };
+
+export async function checkCached(storage: Storage, bucketName: string, springName: string): Promise<boolean> {
+    if (bucketName === 'local') return false;
+    const baseBucketPath = `${springName}/cache-${CACHE_VERSION}`;
+    const [exists] = await storage.bucket(bucketName).file(`${baseBucketPath}/metadata.json`).exists();
+    return exists;
+}

--- a/cloud/map-parser/src/shared.ts
+++ b/cloud/map-parser/src/shared.ts
@@ -1,0 +1,12 @@
+// Must change CACHE_VERSION when making incompatible change to the cache.
+export const CACHE_VERSION = 'v3';
+
+export type ParseResult =
+    | { status: 'not_found' }
+    | { status: 'cached' }
+    | { status: 'fresh' };
+
+export type WorkerInput = {
+    springName: string;
+    tempDir: string;
+};


### PR DESCRIPTION
A set of optimizations to map parser to make it more robust

- Updated map parser lib that has performance improvements
- Make sure there is always up to 1 (well, configurable) number of parsing operations in given process to prevent overload
- Do processing of maps in worker thread to make the service always responsive when pushing back on requests etc
- Support request cancellation
- Cleanup map file earlier to free up memory
- More verbose logging to help debugging