### PR TITLE
Read props from meta.mapInfo as case insensitive.

### DIFF
--- a/scripts/js/src/derived_map_info.ts
+++ b/scripts/js/src/derived_map_info.ts
@@ -129,15 +129,15 @@ export function getDerivedInfo(
         mapHeightMin: meta.minHeight,
         mapHeightMax: meta.maxHeight,
         // Defaults from spring/cont/base/maphelper/maphelper/mapdefaults.lua
-        windMin: orDefault('smd' in meta ? meta.smd.minWind : meta.mapInfo.atmosphere.minWind, 5),
-        windMax: orDefault('smd' in meta ? meta.smd.maxWind : meta.mapInfo.atmosphere.maxWind, 25),
+        windMin: orDefault('smd' in meta ? meta.smd.minWind : meta.mapInfo.atmosphere.minwind, 5),
+        windMax: orDefault('smd' in meta ? meta.smd.maxWind : meta.mapInfo.atmosphere.maxwind, 25),
         windAvg: getAvgWind(
-            orDefault('smd' in meta ? meta.smd.minWind : meta.mapInfo.atmosphere.minWind, 5),
-            orDefault('smd' in meta ? meta.smd.maxWind : meta.mapInfo.atmosphere.maxWind, 25),
+            orDefault('smd' in meta ? meta.smd.minWind : meta.mapInfo.atmosphere.minwind, 5),
+            orDefault('smd' in meta ? meta.smd.maxWind : meta.mapInfo.atmosphere.maxwind, 25),
         ),
-        tidalStrength: 'smd' in meta ? meta.smd.tidalStrength : meta.mapInfo.tidalStrength,
+        tidalStrength: 'smd' in meta ? meta.smd.tidalStrength : meta.mapInfo.tidalstrength,
         version: extractVersion(meta.mapInfo?.version, map.springName),
-        voidWater: orDefault(meta.mapInfo?.voidWater as boolean | undefined, false),
+        voidWater: orDefault(meta.mapInfo?.voidwater as boolean | undefined, false),
         tags: Array.from(mapTags).sort((a, b) => tagsOrder.get(a)! - tagsOrder.get(b)!),
         terrainOrdered: Array.from(map.terrain).sort((a, b) => terrainsOrder.get(a)! - terrainsOrder.get(b)!),
         minPlayerCount: map.minPlayerCount ?? Math.ceil(map.playerCount * 0.6)

--- a/scripts/js/src/maps_metadata.ts
+++ b/scripts/js/src/maps_metadata.ts
@@ -102,6 +102,22 @@ async function getMapFilePath(springName: string, fileName: string): Promise<[st
     return [cachePath, location];
 }
 
+function lowerKeys(value: any): any {
+    if (Array.isArray(value)) {
+        return value.map(lowerKeys);
+    }
+    if (value !== null && typeof value === 'object') {
+        const result: Record<string, any> = {};
+        for (const [k, v] of Object.entries(value)) {
+            const lk = k.toLowerCase();
+            if (lk in result) continue;
+            result[lk] = lowerKeys(v);
+        }
+        return result;
+    }
+    return value;
+}
+
 export async function fetchMapsMetadata(maps: MapList): Promise<Map<string, any>> {
     const limit = pLimit(10);
     // Don't fetch maps metadata from multiple processes in parallel, which happens
@@ -124,6 +140,10 @@ export async function fetchMapsMetadata(maps: MapList): Promise<Map<string, any>
                 throw new Error('This should never happen, key conflict!');
             }
             meta.location = location;
+            // We lower keys, because in Recoil engine, the keys are case insensitive in mapinfo..
+            if (meta.mapInfo) {
+                meta.mapInfo = lowerKeys(meta.mapInfo);
+            }
             return [id, meta];
         }));
         return new Map(await Promise.all(metadata));

--- a/scripts/js/src/sync_to_webflow.ts
+++ b/scripts/js/src/sync_to_webflow.ts
@@ -507,9 +507,9 @@ async function buildWebflowInfo(
             mapTerrains: derivedInfo.terrainOrdered,
             version: derivedInfo.version || null,
             voidWater: derivedInfo.voidWater,
-            waterSurfaceColor: meta.mapInfo?.water?.surfaceColor ? rgbFloatToHex(meta.mapInfo.water.surfaceColor) : null,
-            waterBaseColor: meta.mapInfo?.water?.baseColor ? rgbFloatToHex(meta.mapInfo.water.baseColor) : null,
-            waterMinColor: meta.mapInfo?.water?.minColor ? rgbFloatToHex(meta.mapInfo.water.minColor) : null,
+            waterSurfaceColor: meta.mapInfo?.water?.surfacecolor ? rgbFloatToHex(meta.mapInfo.water.surfacecolor) : null,
+            waterBaseColor: meta.mapInfo?.water?.basecolor ? rgbFloatToHex(meta.mapInfo.water.basecolor) : null,
+            waterMinColor: meta.mapInfo?.water?.mincolor ? rgbFloatToHex(meta.mapInfo.water.mincolor) : null,
             waterAbsorb: meta.mapInfo?.water?.absorb ? meta.mapInfo.water.absorb.join(', ') : null,
             startposCode: map.startboxesSet ? stringify(map.startboxesSet) : null,
         };


### PR DESCRIPTION
That's how engine does it, so we need to comply. Preferably it would be handled in map-parser... but let's patch it here first and then maybe backport it to map-parser as it's a breaking change there.