### PR TITLE
Fix generation of mapBattlePresets.conf for default map

### DIFF
--- a/scripts/js/src/gen_spads_map_presets.ts
+++ b/scripts/js/src/gen_spads_map_presets.ts
@@ -25,7 +25,7 @@ battlePreset:map_DEFAULT
     let battlePreset =
 `${AUTOMATED_HEADER}
 [map_DEFAULT] (transparent)
-${Object.keys(mapModoptions[0].modoptions).join(':\n')}:
+${Array.from(new Set(mapModoptions.flatMap(m => Object.keys(m.modoptions)))).join(':\n')}:
 `;
 
     for (const m of mapModoptions) {


### PR DESCRIPTION
With a91cbd9a9e63dc1229ecc880097468e9ee8620af modoption is set in the map only when it actually exists, so for the default value we have to take union across all the maps, not only first one.